### PR TITLE
fix: inline audio is ignored by GoogleChatRequest

### DIFF
--- a/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
+++ b/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
@@ -270,6 +270,24 @@ internal class VendorGoogleChatRequestMessagePart
                 
                 break;
             }
+            case ChatMessageTypes.Audio:
+            {
+                if (part.Audio is not null)
+                {
+                    if (part.Audio.MimeType is null)
+                    {
+                        throw new Exception("Google requires MIME type of all audio to be set, supported values are: audio/wav, audio/mp3, audio/aiff, audio/aac, audio/ogg, audio/flac");
+                    }
+
+                    InlineData = new VendorGoogleChatRequest.VendorGoogleChatRequestMessagePartInlineData
+                    {
+                        MimeType = part.Audio.MimeType,
+                        Data = part.Audio.Data
+                    };
+                }
+
+                break;
+            }
             case ChatMessageTypes.FileLink:
             {
                 if (part.FileLinkData is not null)


### PR DESCRIPTION
Fix for `GoogleChatRequest` which ignored inline audio which is supported by Gemini: https://ai.google.dev/gemini-api/docs/audio#inline-audio