### PR TITLE
Added support for two extra service_tiers (from Groq) + namespace fix

### DIFF
--- a/src/LlmTornado/Caching/Vendors/Google/VendorGoogleCachingCachedContent.cs
+++ b/src/LlmTornado/Caching/Vendors/Google/VendorGoogleCachingCachedContent.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using LlmTornado.Chat.Vendors.Cohere;
+using LlmTornado.Chat.Vendors.Google;
 using Newtonsoft.Json;
 
 namespace LlmTornado.Caching.Vendors.Google;

--- a/src/LlmTornado/Caching/Vendors/Google/VendorGoogleCachingCreateCachedContentRequest.cs
+++ b/src/LlmTornado/Caching/Vendors/Google/VendorGoogleCachingCreateCachedContentRequest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using LlmTornado.Chat.Vendors.Cohere;
+using LlmTornado.Chat.Vendors.Google;
 using Newtonsoft.Json;
 
 namespace LlmTornado.Caching.Vendors.Google;

--- a/src/LlmTornado/Chat/ChatRequest.cs
+++ b/src/LlmTornado/Chat/ChatRequest.cs
@@ -16,6 +16,7 @@ using LlmTornado.Chat.Vendors.XAi;
 using LlmTornado.Code.Models;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
+using LlmTornado.Chat.Vendors.Google;
 
 namespace LlmTornado.Chat;
 

--- a/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
+++ b/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
@@ -8,7 +8,7 @@ using LlmTornado.Code;
 using LlmTornado.Common;
 using Newtonsoft.Json;
 
-namespace LlmTornado.Chat.Vendors.Cohere;
+namespace LlmTornado.Chat.Vendors.Google;
 
 /// <summary>
 /// Generation config for Google.

--- a/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatResult.cs
+++ b/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatResult.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using LlmTornado.Chat;
 using LlmTornado.Chat.Models;
+using LlmTornado.Chat.Vendors.Google;
 using LlmTornado.ChatFunctions;
 using LlmTornado.Code;
 using LlmTornado.Vendor.Anthropic;

--- a/src/LlmTornado/Code/PartialModels.cs
+++ b/src/LlmTornado/Code/PartialModels.cs
@@ -579,7 +579,19 @@ public enum ChatRequestServiceTiers
     /// If set to 'flex', the request will be processed with the Flex Processing service tier. Learn more.
     /// </summary>
     [EnumMember(Value = "flex")]
-    Flex
+    Flex,
+
+    /// <summary>
+    /// Additional option for service_tier supported by Groq
+    /// </summary>
+    [EnumMember(Value = "on_demand")]
+    OnDemand,
+
+    /// <summary>
+    /// Additional option for service_tier supported by Groq
+    /// </summary>
+    [EnumMember(Value = "performance")]
+    Performance,
 }
 
 /// <summary>

--- a/src/LlmTornado/Embedding/Vendors/Google/VendorGoogleEmbeddingRequest.cs
+++ b/src/LlmTornado/Embedding/Vendors/Google/VendorGoogleEmbeddingRequest.cs
@@ -1,6 +1,6 @@
 using System.Collections.Frozen;
 using System.Collections.Generic;
-using LlmTornado.Chat.Vendors.Cohere;
+using LlmTornado.Chat.Vendors.Google;
 using LlmTornado.Code;
 using Newtonsoft.Json;
 

--- a/src/LlmTornado/Vendor/Google/GoogleEndpointProvider.cs
+++ b/src/LlmTornado/Vendor/Google/GoogleEndpointProvider.cs
@@ -12,6 +12,7 @@ using LlmTornado.Caching;
 using LlmTornado.Chat;
 using LlmTornado.Chat.Vendors.Anthropic;
 using LlmTornado.Chat.Vendors.Cohere;
+using LlmTornado.Chat.Vendors.Google;
 using LlmTornado.Code.Models;
 using LlmTornado.Code.Sse;
 using LlmTornado.Embedding;


### PR DESCRIPTION
I encountered a deserialization issue when calling out to Groq using their OpenAI-compatible endpoint:

Error converting value "on_demand" to type 'System.Nullable`1[LlmTornado.Code.ChatRequestServiceTiers]'. Path 'service_tier', line 1, position 717.

I added the two service tiers in the groq documentation (https://console.groq.com/docs/api-reference). 

Also - noticed a namespace mixup - adjusted it accordingly. 