### PR TITLE
fix: error when disabling gemini thinking

### DIFF
--- a/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
+++ b/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
@@ -807,7 +807,7 @@ internal class VendorGoogleChatRequest
             GenerationConfig.ThinkingConfig = new VendorGoogleChatRequestThinkingConfig
             {
                 ThinkingBudget = clamped,
-                IncludeThoughts = true
+                IncludeThoughts = clamped != 0
             };
         } 
 


### PR DESCRIPTION
When setting the reasoning budget to 0 Gemini on Vertex AI currently reports the following error:
```
{
  "error": {
    "code": 400,
    "message": "Unable to submit request because Thinking_config.include_thoughts is only enabled when thinking is enabled.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini",
    "status": "INVALID_ARGUMENT"
  }
}
```

Fixed it by setting `IncludeThoughts` to false when reasoning is disabled.