### PR TITLE
FEATURE: Multimodal inputs (Image, Audio & video)

### DIFF
--- a/src/LlmTornado/Chat/ChatMessagePart.cs
+++ b/src/LlmTornado/Chat/ChatMessagePart.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -161,7 +161,31 @@ public class ChatMessagePart
 
         Type = ChatMessageTypes.Document;
     }
-    
+
+    /// <summary>
+    ///     The part is an image, audio or video with a publicly available URL.
+    /// </summary>
+    /// <param name="uri">Publicly available URL to the image, audio or video content</param>
+    /// <param name="type">Image, Audio or Video type</param>
+    public ChatMessagePart(Uri uri, ChatMessageTypes type)
+    {
+        switch (type)
+        {
+            case ChatMessageTypes.Image:
+                Image = new ChatImage(uri.ToString());
+                break;
+            case ChatMessageTypes.Audio:
+                Audio = new ChatAudio(uri);
+                break;
+            case ChatMessageTypes.Video:
+                Video = new ChatVideo(uri);
+                break;
+            default:
+                throw new ArgumentException($"Invalid type '{type}'. Only image, audio or video type is allowed.");
+        }
+        Type = type;
+    }
+
     /// <summary>
     ///     The part is a document.
     /// </summary>
@@ -204,7 +228,13 @@ public class ChatMessagePart
     /// </summary>
     [JsonProperty("input_audio")]
     public ChatAudio? Audio { get; set; }
-    
+
+    /// <summary>
+    ///     Image of the message part if type is <see cref="ChatMessageTypes.Video" />.
+    /// </summary>
+    [JsonProperty("video_url")]
+    public ChatVideo? Video { get; set; }
+
     /// <summary>
     ///     Search result of the message part if type is <see cref="ChatMessageTypes.SearchResult" />.
     /// </summary>
@@ -314,5 +344,16 @@ public class ChatMessagePart
     public static ChatMessagePart Create(string documentPathOrBase64, DocumentLinkTypes linkType)
     {
         return new ChatMessagePart(documentPathOrBase64, linkType);
+    }
+
+    /// <summary>
+    ///     Creates an image, audio or video part from a given document.
+    /// </summary>
+    /// <param name="uri">Publicly available URL to the image, audio or video content</param>
+    /// <param name="type">Image, Audio or Video type</param>
+    /// <returns></returns>
+    public static ChatMessagePart Create(Uri uri, ChatMessageTypes type)
+    {
+        return new ChatMessagePart(uri, type);
     }
 }

--- a/src/LlmTornado/Chat/ChatMessageTypes.cs
+++ b/src/LlmTornado/Chat/ChatMessageTypes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 
 namespace LlmTornado.Chat;
@@ -22,7 +22,12 @@ public enum ChatMessageTypes
     /// Message part is an audio fragment.
     /// </summary>
     Audio,
-    
+
+    /// <summary>
+    /// Message part is a video fragment.
+    /// </summary>
+    Video,
+
     /// <summary>
     /// Message part is URI-based file.<br/>
     /// <b>Supported only by Google.</b>

--- a/src/LlmTornado/Chat/ChatRequest.cs
+++ b/src/LlmTornado/Chat/ChatRequest.cs
@@ -874,8 +874,9 @@ public class ChatRequest : IModelRequest
                         {
 	                        ChatMessageTypes.Text => "text",
 	                        ChatMessageTypes.Image => "image_url",
-	                        ChatMessageTypes.Audio => "input_audio",
-	                        _ => "text"
+	                        ChatMessageTypes.Audio => part.Audio?.Url != null ? "audio_url" : "input_audio",
+                            ChatMessageTypes.Video => "video_url",
+                            _ => "text"
                         };
                         
 	                    writer.WriteValue(type);   
@@ -901,38 +902,63 @@ public class ChatRequest : IModelRequest
 	                        }
 	                        case ChatMessageTypes.Audio:
 	                        {
-		                        writer.WritePropertyName("input_audio");
-		                        writer.WriteStartObject();
-								
-		                        writer.WritePropertyName("data");
-		                        writer.WriteValue(part.Audio?.Data);
+								if (part.Audio?.Url != null)
+								{
+                                    writer.WritePropertyName("audio_url");
+                                    writer.WriteStartObject();
 
-		                        writer.WritePropertyName("format");
+                                    writer.WritePropertyName("url");
+                                    writer.WriteValue(part.Audio.Url);
 
-		                        if (part.Audio is not null)
-		                        {
-			                        switch (part.Audio.Format)
-			                        {
-				                        case ChatAudioFormats.Wav:
-				                        {
-					                        writer.WriteValue("wav");
-					                        break;
-				                        }
-				                        case ChatAudioFormats.Mp3:
-				                        {
-					                        writer.WriteValue("mp3");
-					                        break;
-				                        }
-			                        }
-		                        }
-		                        else
-		                        {
-			                        writer.WriteValue(string.Empty);
-		                        }
+                                    writer.WriteEndObject();
+                                    break;
+                                }
+								else
+								{
+									writer.WritePropertyName("input_audio");
+									writer.WriteStartObject();
 
-		                        writer.WriteEndObject();
+									writer.WritePropertyName("data");
+									writer.WriteValue(part.Audio?.Data);
+
+									writer.WritePropertyName("format");
+
+									if (part.Audio is not null)
+									{
+										switch (part.Audio.Format)
+										{
+											case ChatAudioFormats.Wav:
+												{
+													writer.WriteValue("wav");
+													break;
+												}
+											case ChatAudioFormats.Mp3:
+												{
+													writer.WriteValue("mp3");
+													break;
+												}
+										}
+									}
+									else
+									{
+										writer.WriteValue(string.Empty);
+									}
+
+									writer.WriteEndObject();
+								}
 		                        break;
 	                        }
+                            case ChatMessageTypes.Video:
+                                {
+                                    writer.WritePropertyName("video_url");
+                                    writer.WriteStartObject();
+
+                                    writer.WritePropertyName("url");
+                                    writer.WriteValue(part.Video?.Url);
+
+                                    writer.WriteEndObject();
+                                    break;
+                                }
                         }
 
                         writer.WriteEndObject();

--- a/src/LlmTornado/Code/PartialModels.cs
+++ b/src/LlmTornado/Code/PartialModels.cs
@@ -1,4 +1,16 @@
-﻿using System;
+using LlmTornado.Audio;
+using LlmTornado.Chat;
+using LlmTornado.Chat.Vendors.Anthropic;
+using LlmTornado.ChatFunctions;
+using LlmTornado.Code.Models;
+using LlmTornado.Code.Vendor;
+using LlmTornado.Common;
+using LlmTornado.Images;
+using LlmTornado.Infra;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -8,18 +20,6 @@ using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
-using LlmTornado.Images;
-using LlmTornado.Audio;
-using LlmTornado.Chat;
-using LlmTornado.Chat.Vendors.Anthropic;
-using LlmTornado.ChatFunctions;
-using LlmTornado.Code.Models;
-using LlmTornado.Code.Vendor;
-using LlmTornado.Common;
-using LlmTornado.Infra;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
 
 namespace LlmTornado.Code;
 
@@ -950,8 +950,14 @@ public class ChatAudio
     /// <summary>
     ///     Base64 encoded audio data.
     /// </summary>
-    public string Data { get; set; }
-    
+    public string? Data { get; set; }
+
+    /// <summary>
+    ///  Publicly available URL for the video
+    /// </summary>
+    [JsonProperty("audio_url")]
+    public Uri? Url { get; set; }
+
     /// <summary>
     ///     MimeType of the audio.
     /// </summary>
@@ -980,7 +986,16 @@ public class ChatAudio
         Data = data;
         Format = format;
     }
-    
+
+    /// <summary>
+    ///     Creates an audio instance from a publicly available URL
+    /// </summary>
+    /// <param name="uri">Publicly available URL</param>
+    public ChatAudio(Uri uri)
+    {
+        Url = uri;
+    }
+
     /// <summary>
     ///     Creates an audio instance from data and format.
     /// </summary>
@@ -992,6 +1007,27 @@ public class ChatAudio
         Data = data;
         Format = format;
         MimeType = mimeType;
+    }
+}
+
+/// <summary>
+///     Represents a video part of a chat message.
+/// </summary>
+public class ChatVideo
+{
+    /// <summary>
+    ///  Publicly available URL for the video
+    /// </summary>
+    [JsonProperty("video_url")]
+    public Uri Url { get; set; }
+
+    /// <summary>
+    ///     Creates a video url instance from the uri.
+    /// </summary>
+    /// <param name="url">Publicly available URL for the resource</param>
+    public ChatVideo(Uri url)
+    {
+        Url = url;
     }
 }
 


### PR DESCRIPTION
vLLM has extended the OpenAI API to support image, audio and video (https://docs.vllm.ai/en/latest/features/multimodal_inputs.html).
There are additional counterparts to image_url, like video_url or audio_url depending on the file type. Also it is possible to have base64 for other types than images.

This PR allows to add video_url and audio_url message part to the LLM. Closes #56 