### PR TITLE
HttpClient async initialization and with access to IEndpointProvider

### DIFF
--- a/src/LlmTornado/EndpointBase.cs
+++ b/src/LlmTornado/EndpointBase.cs
@@ -52,7 +52,7 @@ public abstract class EndpointBase
     /// Invoked when a <see cref="HttpClient"/> is requested. Can be used to reuse your http client, instead of creating new one. If null is returned, http client is created via the built-in way.
     /// Async version takes precedence.
     /// </summary>
-    public static Func<IEndpointProvider, Task<HttpClient>?>? OnHttpClientRequestedAsync { get; set; }
+    public static Func<IEndpointProvider, Task<HttpClient?>>? OnHttpClientRequestedAsync { get; set; }
 
     /// <summary>
     /// Invoked when a <see cref="HttpClient"/> is requested. Can be used to reuse your http client, instead of creating new one. If null is returned, http client is created via the built-in way.

--- a/src/LlmTornado/TornadoConfig.cs
+++ b/src/LlmTornado/TornadoConfig.cs
@@ -15,7 +15,7 @@ public static class TornadoConfig
     ///     the default way, you are responsible for constructing and returning your own <see cref="HttpClient"/> instance.
     ///     Async version takes precedence.
     /// </summary>
-    public static Func<IEndpointProvider, Task<HttpClient>>? CreateClientAsync { get; set; }
+    public static Func<IEndpointProvider, Task<HttpClient?>>? CreateClientAsync { get; set; }
 
     /// <summary>
     ///     Tornado uses one <see cref="HttpClient"/> per <see cref="LLmProviders"/>, if you set this delegate instead of constructing the client


### PR DESCRIPTION
Currently all overriding of HttpClient creation does not have access to a more detailed context who requests it, just LlmProviders enumeration.

There are 2 issues with it - when using Custom provider, the provider given when constructing HttpClient is converted to an actual one - OpenAi so there is no information on the original provider (IEndpointProvider.Auth.Provider)

Another issue is that there is no possibility of asynchronous creation of HttpClient (requiring some dependencies/settings).

Here is the pull request and example usecase

```cs
private Task<HttpClient> CreateHttpClient(IEndpointProvider provider)
    {
        var certificatePath = PathHelpers.ExpandTilde(GetValue("certificatePath", string.Empty));
        var certificatePassword = GetValue("certificatePassword", string.Empty);
        var handler = new SocketsHttpHandler();
        if (!string.IsNullOrWhiteSpace(certificatePath))
        {
            var certificateMatch = PathHelpers.ExpandTilde(GetValue("certificateMatch", string.Empty));
            var isMatch = string.IsNullOrWhiteSpace(certificateMatch) || (!string.IsNullOrWhiteSpace(provider.Api?.ApiUrlFormat) && Regex.IsMatch(provider.Api.ApiUrlFormat, certificateMatch));
            if (isMatch)
            {
                var clientCertificate = new X509Certificate2(certificatePath, certificatePassword);
                handler.SslOptions = new SslClientAuthenticationOptions
                {
                    ClientCertificates = new X509CertificateCollection { clientCertificate },
                    ClientCertificateContext = SslStreamCertificateContext.Create(clientCertificate, null),
                };
            }
        }

        handler.MaxConnectionsPerServer = GetValue("maxConnectionsPerServer", 10000);
        handler.PooledConnectionLifetime = TimeSpan.FromSeconds(GetValue("pooledConnectionLifetime", 180));

        return Task.FromResult(new HttpClient(handler)
        {
            Timeout = TimeSpan.FromSeconds(GetValue("timeout", 600)),
            DefaultRequestVersion = HttpVersion.Version20
        });

        T GetValue<T>(string propertyName, T defaultValue)
        {
            var llm = provider.Auth?.Provider ?? provider.Provider;
            return configuration.GetValue($"ai:provider:{llm}:{propertyName}", configuration.GetValue($"ai:endpoint:{propertyName}", defaultValue));
        }
    }
```