### PR TITLE
feat(anthropic): enable direct browser access header for API requests

### DIFF
--- a/src/LlmTornado/Vendor/Anthropic/AnthropicEndpointProvider.cs
+++ b/src/LlmTornado/Vendor/Anthropic/AnthropicEndpointProvider.cs
@@ -660,6 +660,7 @@ public class AnthropicEndpointProvider : BaseEndpointProvider, IEndpointProvider
         
         req.Headers.Add("User-Agent", EndpointBase.GetUserAgent());
         req.Headers.Add("anthropic-version", "2023-06-01");
+        req.Headers.Add("anthropic-dangerous-direct-browser-access", "true");
 
         ProviderAuthentication? auth = Api?.GetProvider(LLmProviders.Anthropic).Auth;
 


### PR DESCRIPTION
Add 'anthropic-dangerous-direct-browser-access' header to Anthropic API requests to support browser-based usage. This header is required by Anthropic's API when making requests directly from browser environments, allowing the SDK to function in client-side applications.

Fixes `v3.8.12`

Reference:
- https://simonwillison.net/2024/Aug/23/anthropic-dangerous-direct-browser-access/

Verification Performed:
- Ran local Blazor WASM Standalone with local fix and now able to both list models and perform completions 🎉 