### PR TITLE
Hotfix/missing header for anth models request

### DIFF
--- a/src/LlmTornado/Code/BaseEndpointProvider.cs
+++ b/src/LlmTornado/Code/BaseEndpointProvider.cs
@@ -75,6 +75,30 @@ public abstract class BaseEndpointProvider : IEndpointProviderExtended
     public abstract HttpRequestMessage OutboundMessage(string url, HttpMethod verb, object? data, bool streaming, object? sourceObject);
     public ProviderAuthentication? Auth { get; set; }
     
+    /// <summary>
+    ///     If true, enables direct browser access headers for providers that support it (e.g., Anthropic's "anthropic-dangerous-direct-browser-access" header).
+    ///     This setting must be explicitly enabled as it may bypass certain security restrictions.
+    ///     When set on a provider, it overrides the API-level setting for this specific provider.
+    /// </summary>
+    public bool? DirectBrowserAccess { get; set; }
+    
+    /// <summary>
+    ///     Returns true if direct browser access is enabled either at the API level or provider level.
+    ///     Provider-level setting takes precedence over API-level setting.
+    /// </summary>
+    /// <returns>True if direct browser access is enabled, false otherwise</returns>
+    protected bool IsDirectBrowserAccessEnabled()
+    {
+        // Provider-level setting takes precedence
+        if (DirectBrowserAccess is not null)
+        {
+            return DirectBrowserAccess.Value;
+        }
+        
+        // Fall back to API-level setting
+        return Api?.DirectBrowserAccess ?? false;
+    }
+    
 #if MODERN
     public static Version OutboundDefaultVersion { get; set; } = HttpVersion.Version20;
 #else

--- a/src/LlmTornado/Code/IEndpointProvider.cs
+++ b/src/LlmTornado/Code/IEndpointProvider.cs
@@ -109,6 +109,13 @@ public interface IEndpointProvider
     /// JSON schema capabilities of the provider.
     /// </summary>
     public JsonSchemaCapabilities JsonSchemaCapabilities { get; }
+    
+    /// <summary>
+    ///     If true, enables direct browser access headers for providers that support it (e.g., Anthropic's "anthropic-dangerous-direct-browser-access" header).
+    ///     This setting must be explicitly enabled as it may bypass certain security restrictions.
+    ///     When set on a provider, it overrides the API-level setting for this specific provider.
+    /// </summary>
+    public bool? DirectBrowserAccess { get; set; }
 }
 
 /// <summary>

--- a/src/LlmTornado/TornadoApi.cs
+++ b/src/LlmTornado/TornadoApi.cs
@@ -63,6 +63,12 @@ public class TornadoApi
     internal bool HttpStrict { get; set; }
     
     /// <summary>
+    ///     If true, enables direct browser access headers for providers that support it (e.g., Anthropic's "anthropic-dangerous-direct-browser-access" header).
+    ///     This setting must be explicitly enabled as it may bypass certain security restrictions.
+    /// </summary>
+    public bool DirectBrowserAccess { get; set; }
+    
+    /// <summary>
     ///     Creates a new Tornado API without any authentication. Use this with self-hosted models.
     /// </summary>
     public TornadoApi()

--- a/src/LlmTornado/Vendor/Anthropic/AnthropicEndpointProvider.cs
+++ b/src/LlmTornado/Vendor/Anthropic/AnthropicEndpointProvider.cs
@@ -660,7 +660,11 @@ public class AnthropicEndpointProvider : BaseEndpointProvider, IEndpointProvider
         
         req.Headers.Add("User-Agent", EndpointBase.GetUserAgent());
         req.Headers.Add("anthropic-version", "2023-06-01");
-        req.Headers.Add("anthropic-dangerous-direct-browser-access", "true");
+        
+        if (IsDirectBrowserAccessEnabled())
+        {
+            req.Headers.Add("anthropic-dangerous-direct-browser-access", "true");
+        }
 
         ProviderAuthentication? auth = Api?.GetProvider(LLmProviders.Anthropic).Auth;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `DirectBrowserAccess` setting (API- and provider-level) and conditionally sends Anthropic's `anthropic-dangerous-direct-browser-access` header when enabled.
> 
> - **Provider infrastructure**:
>   - Add `DirectBrowserAccess` to `TornadoApi`, `IEndpointProvider`, and `BaseEndpointProvider` with provider-over-API precedence via `IsDirectBrowserAccessEnabled()`.
> - **Anthropic provider**:
>   - In `OutboundMessage`, conditionally add `anthropic-dangerous-direct-browser-access: true` when direct browser access is enabled.
>   - Keep existing headers (`User-Agent`, `anthropic-version`, `x-api-key`, `anthropic-beta`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b5a7520d619e2cd28cbfb4d07854cd38bd63a38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->