### PR TITLE
Removed duplicate keys in ChatMessageFinishReasonsConverter due to the IgnoreCase

### DIFF
--- a/src/LlmTornado/Code/PartialModels.cs
+++ b/src/LlmTornado/Code/PartialModels.cs
@@ -303,15 +303,12 @@ internal class ChatMessageFinishReasonsConverter : JsonConverter<ChatMessageFini
     {
         { "stop", ChatMessageFinishReasons.EndTurn },
         { "end_turn", ChatMessageFinishReasons.EndTurn },
-        { "STOP", ChatMessageFinishReasons.EndTurn },
-        { "COMPLETE", ChatMessageFinishReasons.EndTurn },
+        { "complete", ChatMessageFinishReasons.EndTurn },
 
         { "stop_sequence", ChatMessageFinishReasons.StopSequence },
-        { "STOP_SEQUENCE", ChatMessageFinishReasons.StopSequence },
 
         { "length", ChatMessageFinishReasons.Length },
         { "max_tokens", ChatMessageFinishReasons.Length },
-        { "MAX_TOKENS", ChatMessageFinishReasons.Length },
         { "ERROR_LIMIT", ChatMessageFinishReasons.Length },
 
         { "content_filter", ChatMessageFinishReasons.ContentFilter },


### PR DESCRIPTION
Solves https://github.com/lofcz/LLMTornado/issues/115