### PR TITLE
fix: Correction of event parameter passing in streaming inference

### DIFF
--- a/src/LlmTornado.Agents/DataModels/ModelStreamingEvents.cs
+++ b/src/LlmTornado.Agents/DataModels/ModelStreamingEvents.cs
@@ -739,7 +739,7 @@ public class ModelStreamingReasoningPartAddedEvent : ModelStreamingEvents
     /// <param name="itemId">The unique identifier for the reasoning item.</param>
     /// <param name="reasoningText">The reasoning text content that was added. Defaults to an empty string if not provided.</param>
     /// <param name="responseID">An optional identifier for the response associated with this event. Defaults to an empty string if not provided.</param>
-    public ModelStreamingReasoningPartAddedEvent(int seqNum, int outputIndex, int summaryPartIndex, string itemId, string reasoningText = "", string responseID = "")
+    public ModelStreamingReasoningPartAddedEvent(int seqNum, int outputIndex, int summaryPartIndex,  string reasoningText = "", string itemId = "", string responseID = "")
         : base(seqNum, responseID, ModelStreamingEventType.ReasoningPartAdded, ModelStreamingStatus.Completed)
     {
         OutputIndex = outputIndex;

--- a/src/LlmTornado.Agents/TornadoRunner.cs
+++ b/src/LlmTornado.Agents/TornadoRunner.cs
@@ -583,7 +583,7 @@ public class TornadoRunner
             {
                 if (runnerCallback is not null)
                 {
-                    await runnerCallback.Invoke(new AgentRunnerStreamingEvent(new ModelStreamingReasoningPartAddedEvent(1, 1, 1, string.Empty, reasoning.Content ?? string.Empty), chat));
+                    await runnerCallback.Invoke(new AgentRunnerStreamingEvent(new ModelStreamingReasoningPartAddedEvent(1, 1, 1, reasoningText: reasoning.Content ?? string.Empty), chat));
                 }
             },
             BlockFinishedHandler = (message) =>


### PR DESCRIPTION
Adjust the ModelStreamingReasoning PartAddeEvent call to ensure that the parameters are passed correctly.