### PR TITLE
fix reasoning tokens not handled for ollama qwen3:4b

### DIFF
--- a/src/LlmTornado/Chat/ChatMessage.cs
+++ b/src/LlmTornado/Chat/ChatMessage.cs
@@ -185,6 +185,12 @@ public class ChatMessage
     [JsonIgnore]
     internal bool ExcludeFromRequest { get; set; }
 
+    /// <summary>
+    /// A property that retrieves the reasoning tokens of the message. Favors the value from
+    /// <see cref="ReasoningContent" /> if available; otherwise, falls back to <see cref="Reasoning" />.
+    /// </summary>
+    [JsonIgnore] public string? ReasoningTokens => ReasoningContent ?? Reasoning;
+
     [JsonIgnore] 
     internal Dictionary<string, ToolCallInboundAccumulator>? ToolCallsDict;
     

--- a/src/LlmTornado/Chat/Conversation.cs
+++ b/src/LlmTornado/Chat/Conversation.cs
@@ -1103,10 +1103,10 @@ public class Conversation
                 {
                     Type = ChatRichResponseBlockTypes.Message,
                     Message = newMsg.Content,
-                    Reasoning = newMsg.ReasoningContent is null || newMsg.Reasoning is not null ? null : new ChatMessageReasoningData
+                    Reasoning = newMsg.ReasoningTokens is null ? null : new ChatMessageReasoningData
                     {
-                        Content  = newMsg.ReasoningContent ?? newMsg.Reasoning ,
-                        Provider = res.Provider?.Provider  ?? LLmProviders.OpenAi
+                        Content  = newMsg.ReasoningTokens,
+                        Provider = res.Provider?.Provider ?? LLmProviders.OpenAi
                     }
                 });
             }
@@ -1119,14 +1119,14 @@ public class Conversation
                 });
             }
 
-            if (!(newMsg.ReasoningContent ?? newMsg.Reasoning).IsNullOrWhiteSpace() && !blocks.Any(x => x.Type is ChatRichResponseBlockTypes.Reasoning))
+            if (!newMsg.ReasoningTokens.IsNullOrWhiteSpace() && !blocks.Any(x => x.Type is ChatRichResponseBlockTypes.Reasoning))
             {
                 blocks.Add(new ChatRichResponseBlock
                 {
                     Type = ChatRichResponseBlockTypes.Reasoning,
                     Reasoning = new ChatMessageReasoningData
                     {
-                        Content = newMsg.ReasoningContent ?? newMsg.Reasoning
+                        Content = newMsg.ReasoningTokens
                     }
                 });
             }
@@ -2003,13 +2003,13 @@ public class Conversation
                             }
                             else
                             {
-                                if (delta.ReasoningContent is not null || delta.Reasoning is not null)
+                                if (delta.ReasoningTokens is not null)
                                 {
                                     if (eventsHandler.ReasoningTokenHandler is not null)
                                     {
                                         await eventsHandler.ReasoningTokenHandler.Invoke(new ChatMessageReasoningData
                                         {
-                                            Content  = delta.ReasoningContent ?? delta.Reasoning,
+                                            Content  = delta.ReasoningTokens,
                                             Provider = provider.Provider
                                         });
                                     }
@@ -2021,7 +2021,6 @@ public class Conversation
                                     {
                                         Type = ChatMessageTypes.Text,
                                         Text = delta.Content ?? message?.Content
-                                        
                                     });
                                 }
 

--- a/src/LlmTornado/Chat/Vendors/XAi/ChatResultVendorXAi.cs
+++ b/src/LlmTornado/Chat/Vendors/XAi/ChatResultVendorXAi.cs
@@ -30,7 +30,7 @@ internal class ChatResultVendorXAi : ChatResult
             {
                 foreach (ChatChoice choice in resultEx.Choices)
                 {
-                    if (choice.Message is not null && (choice.Message.ReasoningContent is not null || choice.Message.Reasoning is not null))
+                    if (choice.Message is not null && choice.Message.ReasoningTokens is not null)
                     {
                         choice.Message.Parts ??= [];
                         
@@ -51,7 +51,7 @@ internal class ChatResultVendorXAi : ChatResult
                         {
                             choice.Message.Parts.Add(new ChatMessagePart(new ChatMessageReasoningData
                             {
-                                Content = choice.Message.ReasoningContent ?? choice.Message.Reasoning,
+                                Content  = choice.Message.ReasoningTokens,
                                 Provider = LLmProviders.XAi
                             }));
                         }

--- a/src/LlmTornado/Vendor/OpenAi/OpenAiEndpointProvider.cs
+++ b/src/LlmTornado/Vendor/OpenAi/OpenAiEndpointProvider.cs
@@ -392,10 +392,10 @@ public class OpenAiEndpointProvider : BaseEndpointProvider, IEndpointProvider, I
                     
                     choice.Delta.Role = ChatMessageRoles.Assistant;
 
-                    if (choice.Delta.ReasoningContent is not null || choice.Delta.Reasoning is not null)
+                    if (choice.Delta.ReasoningTokens is not null)
                     {
                         reasoningBuilder ??= new StringBuilder();
-                        reasoningBuilder.Append(choice.Delta.ReasoningContent ?? choice.Delta.Reasoning);
+                        reasoningBuilder.Append(choice.Delta.ReasoningTokens);
                     }
 
                     if (choice.Delta.Content is not null)


### PR DESCRIPTION
fix handeling of reasoning tokens for ollama running qwen3:4b as that uses the "reasoning" instead of "reasoning_content"

I also added the handleing of both fields to the xAI and Openai providers. I didn' t have time to test those both though