### PR TITLE
Add support for reasoning content to Microsoft.Extensions.AI integration

### DIFF
--- a/src/LlmTornado.Microsoft.Extensions.AI/TypeConverters.cs
+++ b/src/LlmTornado.Microsoft.Extensions.AI/TypeConverters.cs
@@ -47,6 +47,16 @@ internal static class TypeConverters
                         }
                         break;
 
+                    case TextReasoningContent reasoningContent:
+                        if (!string.IsNullOrEmpty(reasoningContent.Text))
+                        {
+                            parts.Add(new ChatMessagePart(new ChatMessageReasoningData()
+                            {
+                                Content = reasoningContent.Text
+                            }));
+                        }
+                        break;
+
                     case UriContent imageContent:
                         if (!string.IsNullOrEmpty(imageContent.Uri.AbsolutePath))
                         {
@@ -132,6 +142,12 @@ internal static class TypeConverters
             contents.Add(new TextContent(message.Content));
         }
 
+        // Add reasoning content
+        if (!string.IsNullOrEmpty(message.ReasoningTokens))
+        {
+            contents.Add(new TextReasoningContent(message.ReasoningTokens));
+        }
+
         // Add parts if available
         if (message.Parts != null)
         {
@@ -143,6 +159,13 @@ internal static class TypeConverters
                         if (!string.IsNullOrEmpty(part.Text))
                         {
                             contents.Add(new TextContent(part.Text));
+                        }
+                        break;
+
+                    case ChatMessageTypes.Reasoning:
+                        if (!string.IsNullOrEmpty(part.Text))
+                        {
+                            contents.Add(new TextReasoningContent(part.Text));
                         }
                         break;
 


### PR DESCRIPTION
Currently Microsoft.Extensions.AI integration doesn't support reasoning content.

This PR maps reasoning content to TextReasoningContent on MEAI side.

Sample usage:

```csharp
TornadoApi api = new(endpointUrl, apiKey);

var chatClient = api.AsChatClient(modelName);
List<ChatMessage> messages = [
    new(ChatRole.User, "Why is sky blue?")
];

var response = await chatClient.GetResponseAsync(messages);

// Standard message.Text usage (unchanged):
Console.WriteLine(response.Messages.FirstOrDefault()?.Text);

// Grab the TextContent only (unchanged):
Console.WriteLine(response.Messages.FirstOrDefault()?.Contents.OfType<TextContent>().FirstOrDefault()?.Text);

// Grab the TextReasoningContent only (now supported):
Console.WriteLine(response.Messages.FirstOrDefault()?.Contents.OfType<TextReasoningContent>().FirstOrDefault()?.Text);
```