### PR TITLE
Fix Mistral API rejecting requests due to strict validation

### DIFF
--- a/src/LlmTornado/Chat/Vendors/Mistral/MistralChatMessageConverter.cs
+++ b/src/LlmTornado/Chat/Vendors/Mistral/MistralChatMessageConverter.cs
@@ -178,7 +178,7 @@ internal class MistralChatMessageConverter : JsonConverter<ChatMessage>
             {
                 Id = tc["id"]?.ToString(),
                 Type = tc["type"]?.ToString(),
-                FunctionCall = tc["function_call"] is JObject fn
+                FunctionCall = tc["function"] is JObject fn
                     ? new FunctionCall
                     {
                         Name = fn["name"]?.ToString(),

--- a/src/LlmTornado/Chat/Vendors/Mistral/VendorMistralChatRequest.cs
+++ b/src/LlmTornado/Chat/Vendors/Mistral/VendorMistralChatRequest.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Linq;
 using LlmTornado.Code;
+using LlmTornado.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -10,28 +12,27 @@ namespace LlmTornado.Chat.Vendors.Mistral;
 /// </summary>
 internal class VendorMistralChatRequest
 {
-    public VendorMistralChatRequestData? ExtendedRequest { get; set; }
-    public ChatRequest? NativeRequest { get; set; }
-    
+    public VendorMistralChatRequestData ExtendedRequest { get; set; }
+
     [JsonIgnore]
     public ChatMessage? TempMessage { get; set; }
-    
+
     [JsonIgnore]
     public ChatRequest SourceRequest { get; set; }
-    
+
     public JObject Serialize(JsonSerializerSettings settings)
     {
         JsonSerializer serializer = JsonSerializer.CreateDefault(settings);
-        JObject jsonPayload = JObject.FromObject(ExtendedRequest ?? NativeRequest, serializer);
-        
+        JObject jsonPayload = JObject.FromObject(ExtendedRequest, serializer);
+
         if (TempMessage is not null)
         {
             SourceRequest.Messages?.Remove(TempMessage);
         }
-        
+
         return jsonPayload;
     }
-    
+
     internal class VendorMistralChatRequestData : ChatRequest
     {
         [JsonProperty("safe_prompt")]
@@ -39,40 +40,91 @@ internal class VendorMistralChatRequest
 
         [JsonProperty("prediction")]
         public Prediction? Prediction { get; set; }
-        
+
         [JsonProperty("prompt_mode")]
         public MistralPromptMode? PromptMode { get; set; }
-        
+
         [JsonProperty("random_seed")]
         public int? RandomSeed { get; set; }
-        
+
+        [JsonProperty("tools", NullValueHandling = NullValueHandling.Ignore)]
+        public new List<VendorMistralTool>? Tools { get; set; }
+
         public VendorMistralChatRequestData(ChatRequest request) : base(request)
         {
-            
+            // Mistral's strict API rejects properties it doesn't support
+            Verbosity = null;
+
+            if (request.Tools is { Count: > 0 })
+            {
+                List<VendorMistralTool> tools = [];
+                foreach (Tool t in request.Tools)
+                {
+                    if (t.Function is not null)
+                    {
+                        tools.Add(new VendorMistralTool
+                        {
+                            Function = new VendorMistralToolFunction
+                            {
+                                Name = t.Function.Name,
+                                Description = t.Function.Description,
+                                Parameters = t.Function.Parameters,
+                                Strict = t.Strict
+                            }
+                        });
+                    }
+                }
+                Tools = tools;
+                base.Tools = null;
+            }
         }
+    }
+
+    internal class VendorMistralTool
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; } = "function";
+
+        [JsonProperty("function")]
+        public VendorMistralToolFunction? Function { get; set; }
+    }
+
+    internal class VendorMistralToolFunction
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Description { get; set; }
+
+        [JsonProperty("parameters", NullValueHandling = NullValueHandling.Ignore)]
+        public object? Parameters { get; set; }
+
+        [JsonProperty("strict", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Strict { get; set; }
     }
 
     internal class Prediction
     {
         [JsonProperty("type")]
         public string Type { get; set; } = "content";
-        
+
         [JsonProperty("content")]
         public string Content { get; set; }
     }
-    
+
     public VendorMistralChatRequest(ChatRequest request, IEndpointProvider provider)
     {
         // not supported
         request.StreamOptions = null;
-        
+
         SourceRequest = request;
         ChatRequestVendorMistralExtensions? extensions = request.VendorExtensions?.Mistral;
 
+        ExtendedRequest = new VendorMistralChatRequestData(request);
+
         if (extensions is not null)
         {
-            ExtendedRequest = new VendorMistralChatRequestData(request);
-            
             if (extensions.SafePrompt is not null)
             {
                 ExtendedRequest.SafePrompt = extensions.SafePrompt;
@@ -103,13 +155,9 @@ internal class VendorMistralChatRequest
                     {
                         Prefix = true
                     };
-                    request.Messages?.Add(TempMessage);   
+                    request.Messages?.Add(TempMessage);
                 }
             }
-        }
-        else
-        {
-            NativeRequest = request;
         }
     }
 }


### PR DESCRIPTION
  - Add vendor-specific tool wrapper classes (VendorMistralTool/VendorMistralToolFunction) to avoid serializing extra properties (ResolvedName, ResolvedDescription) that Mistral's strict API rejects
  - Always route through VendorMistralChatRequestData to also strip unsupported fields like Verbosity
  - Fix MistralChatMessageConverter.ParseToolCalls reading wrong key ("function_call" instead of "function"), which caused tool calls in conversation history to lose their function data