### PR TITLE
Fix Gemini batch creation to use JSONL file uploads

### DIFF
--- a/src/LlmTornado/Batch/Vendors/Google/VendorGoogleBatchHandler.cs
+++ b/src/LlmTornado/Batch/Vendors/Google/VendorGoogleBatchHandler.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LlmTornado.Code;
 using LlmTornado.Common;
+using LlmTornado.Files;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -18,6 +19,7 @@ internal static class VendorGoogleBatchHandler
 {
     public static async Task<HttpCallResult<BatchItem>> Create(BatchRequest request, IEndpointProvider provider, EndpointBase endpoint, CancellationToken cancellationToken)
     {
+        TornadoApi api = provider.Api!;
         string? model = request.Requests.FirstOrDefault()?.Params.Model?.Name;
         if (string.IsNullOrEmpty(model))
         {
@@ -26,12 +28,35 @@ internal static class VendorGoogleBatchHandler
                 Exception = new ArgumentException("Model must be specified in batch request items for Google/Gemini")
             };
         }
-        
-        VendorGoogleBatchRequest googleRequest = new VendorGoogleBatchRequest(request, provider);
+
+        byte[] jsonlBytes = VendorGoogleBatchRequest.SerializeToJsonlBytes(request, provider);
+
+        HttpCallResult<TornadoFile> uploadResult = await api.Files.Upload(new FileUploadRequest
+        {
+            Bytes = jsonlBytes,
+            Name = $"batch_{Guid.NewGuid():N}.jsonl",
+            MimeType = "application/jsonl"
+        }, provider.Provider).ConfigureAwait(false);
+
+        if (!uploadResult.Ok || string.IsNullOrEmpty(uploadResult.Data?.Id))
+        {
+            return new HttpCallResult<BatchItem>(
+                uploadResult.Code,
+                uploadResult.Response,
+                null,
+                false,
+                uploadResult.Request
+            )
+            {
+                Exception = uploadResult.Exception ?? new Exception("Failed to upload Gemini batch input file")
+            };
+        }
+
+        VendorGoogleBatchRequest googleRequest = new VendorGoogleBatchRequest(request, uploadResult.Data.Id);
         string body = googleRequest.Serialize();
-        
+
         string url = provider.ApiUrl(CapabilityEndpoints.BaseUrl, $"models/{model}:batchGenerateContent");
-        
+
         return await endpoint.HttpPost<BatchItem>(provider, CapabilityEndpoints.Batch, url, body, ct: cancellationToken).ConfigureAwait(false);
     }
     

--- a/src/LlmTornado/Batch/Vendors/Google/VendorGoogleBatchRequest.cs
+++ b/src/LlmTornado/Batch/Vendors/Google/VendorGoogleBatchRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text;
 using LlmTornado.Chat.Vendors.Google;
 using LlmTornado.Code;
 using Newtonsoft.Json;
@@ -6,42 +7,21 @@ using Newtonsoft.Json;
 namespace LlmTornado.Batch.Vendors.Google;
 
 /// <summary>
-/// Google/Gemini-specific batch request metadata for each inlined request.
+/// Google/Gemini-specific JSONL batch request line.
 /// </summary>
-internal class VendorGoogleBatchRequestMetadata
+internal class VendorGoogleBatchRequestLine
 {
     [JsonProperty("key")]
     public string Key { get; set; } = string.Empty;
-}
 
-/// <summary>
-/// Google/Gemini-specific inlined request item.
-/// </summary>
-internal class VendorGoogleBatchInlinedRequest
-{
     [JsonProperty("request")]
     public VendorGoogleChatRequest Request { get; set; }
-    
-    [JsonProperty("metadata")]
-    public VendorGoogleBatchRequestMetadata Metadata { get; set; }
-    
-    public VendorGoogleBatchInlinedRequest(BatchRequestItem item, IEndpointProvider provider)
-    {
-        Request = new VendorGoogleChatRequest(item.Params, provider);
-        Metadata = new VendorGoogleBatchRequestMetadata
-        {
-            Key = item.CustomId
-        };
-    }
-}
 
-/// <summary>
-/// Wrapper for inlined requests array.
-/// </summary>
-internal class VendorGoogleBatchInlinedRequestsWrapper
-{
-    [JsonProperty("requests")]
-    public List<VendorGoogleBatchInlinedRequest> Requests { get; set; } = [];
+    public VendorGoogleBatchRequestLine(BatchRequestItem item, IEndpointProvider provider)
+    {
+        Key = item.CustomId;
+        Request = new VendorGoogleChatRequest(item.Params, provider);
+    }
 }
 
 /// <summary>
@@ -49,11 +29,13 @@ internal class VendorGoogleBatchInlinedRequestsWrapper
 /// </summary>
 internal class VendorGoogleBatchInputConfig
 {
-    [JsonProperty("requests")]
-    public VendorGoogleBatchInlinedRequestsWrapper? Requests { get; set; }
-    
     [JsonProperty("file_name")]
-    public string? FileName { get; set; }
+    public string FileName { get; set; }
+
+    public VendorGoogleBatchInputConfig(string fileName)
+    {
+        FileName = fileName;
+    }
 }
 
 /// <summary>
@@ -65,10 +47,15 @@ internal class VendorGoogleBatchConfig
     public string? DisplayName { get; set; }
     
     [JsonProperty("input_config")]
-    public VendorGoogleBatchInputConfig InputConfig { get; set; } = new();
+    public VendorGoogleBatchInputConfig InputConfig { get; set; }
     
     [JsonProperty("priority")]
     public string? Priority { get; set; }
+
+    public VendorGoogleBatchConfig(VendorGoogleBatchInputConfig inputConfig)
+    {
+        InputConfig = inputConfig;
+    }
 }
 
 /// <summary>
@@ -77,20 +64,15 @@ internal class VendorGoogleBatchConfig
 internal class VendorGoogleBatchRequest
 {
     [JsonProperty("batch")]
-    public VendorGoogleBatchConfig Batch { get; set; } = new();
-    
-    public VendorGoogleBatchRequest(BatchRequest request, IEndpointProvider provider)
+    public VendorGoogleBatchConfig Batch { get; set; }
+
+    public VendorGoogleBatchRequest(BatchRequest request, string inputFileId)
     {
-        Batch.InputConfig.Requests = new VendorGoogleBatchInlinedRequestsWrapper();
-        
-        foreach (BatchRequestItem item in request.Requests)
-        {
-            Batch.InputConfig.Requests.Requests.Add(new VendorGoogleBatchInlinedRequest(item, provider));
-        }
-        
+        Batch = new VendorGoogleBatchConfig(new VendorGoogleBatchInputConfig(inputFileId));
+
         // Set display name from vendor extensions if provided
         Batch.DisplayName = request.VendorExtensions?.Google?.DisplayName ?? $"batch_{System.Guid.NewGuid():N}";
-        
+
         // Set priority if provided
         if (request.VendorExtensions?.Google?.Priority is not null)
         {
@@ -104,5 +86,30 @@ internal class VendorGoogleBatchRequest
     public string Serialize()
     {
         return JsonConvert.SerializeObject(this, EndpointBase.NullSettings);
+    }
+
+    /// <summary>
+    /// Serializes batch request items to JSONL format for Gemini file uploads.
+    /// </summary>
+    public static string SerializeToJsonl(BatchRequest request, IEndpointProvider provider)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        foreach (BatchRequestItem item in request.Requests)
+        {
+            VendorGoogleBatchRequestLine line = new VendorGoogleBatchRequestLine(item, provider);
+            string json = JsonConvert.SerializeObject(line, EndpointBase.NullSettings);
+            sb.AppendLine(json);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Serializes batch request items to JSONL bytes for Gemini file uploads.
+    /// </summary>
+    public static byte[] SerializeToJsonlBytes(BatchRequest request, IEndpointProvider provider)
+    {
+        return Encoding.UTF8.GetBytes(SerializeToJsonl(request, provider));
     }
 }


### PR DESCRIPTION
Fix https://github.com/lofcz/LLMTornado/issues/162

IMO using file-based API in Gemini should be used by default as it has no limitations and can be used for both big and small batches compared to inline requests which only support small batches.