### PR TITLE
anthropic: claude opus 4.7

### DIFF
--- a/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropic.cs
+++ b/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropic.cs
@@ -40,7 +40,12 @@ public class ChatModelAnthropic : BaseVendorModelProvider
     /// Claude 4.6 models.
     /// </summary>
     public readonly ChatModelAnthropicClaude46 Claude46 = new ChatModelAnthropicClaude46();
-    
+
+    /// <summary>
+    /// Claude 4.7 models.
+    /// </summary>
+    public readonly ChatModelAnthropicClaude47 Claude47 = new ChatModelAnthropicClaude47();
+
     /// <inheritdoc cref="BaseVendorModelProvider.Provider"/>
     public override LLmProviders Provider => LLmProviders.Anthropic;
 
@@ -78,7 +83,7 @@ public class ChatModelAnthropic : BaseVendorModelProvider
     /// </summary>
     public static List<IModel> ModelsAll => LazyModelsAll.Value;
 
-    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [..ChatModelAnthropicClaude3.ModelsAll, ..ChatModelAnthropicClaude35.ModelsAll, ..ChatModelAnthropicClaude4.ModelsAll, ..ChatModelAnthropicClaude41.ModelsAll, ..ChatModelAnthropicClaude45.ModelsAll, ..ChatModelAnthropicClaude46.ModelsAll]);
+    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [..ChatModelAnthropicClaude3.ModelsAll, ..ChatModelAnthropicClaude35.ModelsAll, ..ChatModelAnthropicClaude4.ModelsAll, ..ChatModelAnthropicClaude41.ModelsAll, ..ChatModelAnthropicClaude45.ModelsAll, ..ChatModelAnthropicClaude46.ModelsAll, ..ChatModelAnthropicClaude47.ModelsAll]);
     
     internal ChatModelAnthropic()
     {

--- a/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropicClaude47.cs
+++ b/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropicClaude47.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using LlmTornado.Code;
+using LlmTornado.Code.Models;
+
+namespace LlmTornado.Chat.Models;
+
+/// <summary>
+/// Claude 4.7 class models from Anthropic.
+/// </summary>
+public class ChatModelAnthropicClaude47 : IVendorModelClassProvider
+{
+    /// <summary>
+    /// Claude Opus 4.7 - Anthropic's most intelligent model for building agents and coding.
+    /// Supports a 200K context window (1M available in beta).
+    /// Alias: <c>claude-opus-4-7</c>.
+    /// </summary>
+    public static readonly ChatModel ModelOpus = new ChatModel("claude-opus-4-7", LLmProviders.Anthropic, 200_000);
+
+    /// <summary>
+    /// <inheritdoc cref="ModelOpus"/>
+    /// </summary>
+    public readonly ChatModel Opus = ModelOpus;
+
+    /// <summary>
+    /// All known Claude 4.7 models from Anthropic.
+    /// </summary>
+    public static List<IModel> ModelsAll => LazyModelsAll.Value;
+
+    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [
+        ModelOpus
+    ]);
+
+    /// <summary>
+    /// <inheritdoc cref="ModelsAll"/>
+    /// </summary>
+    public List<IModel> AllModels => ModelsAll;
+
+    internal ChatModelAnthropicClaude47()
+    {
+
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for **Claude Opus 4.7** (`claude-opus-4-7`), released by Anthropic after the v3.8.56 cut.

- New `ChatModelAnthropicClaude47` class mirroring the 4.6 layout, exposing `ModelOpus` with a 200K context window.
- Registered on `ChatModelAnthropic.Claude47` and included in `ChatModelAnthropic.ModelsAll`.
- No Sonnet/Haiku 4.7 yet — Anthropic has only shipped Opus at this tier so far. The file is structured to make adding them trivial when they land.

Usage:

\`\`\`csharp
new ChatModelAnthropic().Claude47.Opus
// or
ChatModelAnthropicClaude47.ModelOpus
\`\`\`

## Notes

- No dated snapshot alias (e.g. \`claude-opus-4-7-20260XXX\`) is registered — happy to add it if you can point me at the canonical release-date suffix.
- Build is green locally (0 errors).

## Test plan

- [x] \`dotnet build -c Release\` on \`src/LlmTornado\` — 0 errors
- [ ] Smoke test via Demo project against the live Anthropic API