### PR TITLE
Abstraction for Latest Model Pointers

### DIFF
--- a/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropic.cs
+++ b/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropic.cs
@@ -12,6 +12,11 @@ namespace LlmTornado.Chat.Models;
 public class ChatModelAnthropic : BaseVendorModelProvider
 {
     /// <summary>
+    /// Latest models by performance tier (Max/Large/Medium/Small). Pointers repointed as newer models release.
+    /// </summary>
+    public readonly ChatModelAnthropicLatest Latest = new ChatModelAnthropicLatest();
+
+    /// <summary>
     /// Claude 3 models.
     /// </summary>
     public readonly ChatModelAnthropicClaude3 Claude3 = new ChatModelAnthropicClaude3();

--- a/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropicLatest.cs
+++ b/src/LlmTornado/Chat/Models/Anthropic/ChatModelAnthropicLatest.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using LlmTornado.Code.Models;
+
+namespace LlmTornado.Chat.Models;
+
+/// <summary>
+/// Latest models from Anthropic by performance tier. These are pointers to existing models, repointed to newer models
+/// as they release; pin a concrete snapshot (e.g. <see cref="ChatModelAnthropicClaude5.Fable"/>) if you need a stable model.
+/// </summary>
+public class ChatModelAnthropicLatest : IVendorModelClassProvider
+{
+    /// <summary>
+    /// Absolute top-end tier; slowest and most expensive. Currently <c>claude-fable-5</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMax = ChatModelAnthropicClaude5.ModelFable;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMax"/>
+    /// </summary>
+    public readonly ChatModel Max = ModelMax;
+
+    /// <summary>
+    /// Flagship / frontier tier. Currently <c>claude-opus-4-8</c>.
+    /// </summary>
+    public static readonly ChatModel ModelLarge = ChatModelAnthropicClaude48.ModelOpus;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelLarge"/>
+    /// </summary>
+    public readonly ChatModel Large = ModelLarge;
+
+    /// <summary>
+    /// Balanced intelligence/cost tier. Currently <c>claude-sonnet-5</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMedium = ChatModelAnthropicClaude5.ModelSonnet;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMedium"/>
+    /// </summary>
+    public readonly ChatModel Medium = ModelMedium;
+
+    /// <summary>
+    /// Cheap, fast, high-volume tier. Currently <c>claude-haiku-4-5-20251001</c>.
+    /// </summary>
+    public static readonly ChatModel ModelSmall = ChatModelAnthropicClaude45.ModelHaiku251001;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelSmall"/>
+    /// </summary>
+    public readonly ChatModel Small = ModelSmall;
+
+    /// <summary>
+    /// Models currently pointed to by the latest tiers of Anthropic.
+    /// </summary>
+    public static List<IModel> ModelsAll => LazyModelsAll.Value;
+
+    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [
+        ModelMax, ModelLarge, ModelMedium, ModelSmall
+    ]);
+
+    /// <summary>
+    /// <inheritdoc cref="ModelsAll"/>
+    /// </summary>
+    public List<IModel> AllModels => ModelsAll;
+
+    internal ChatModelAnthropicLatest()
+    {
+
+    }
+}

--- a/src/LlmTornado/Chat/Models/ChatModel.cs
+++ b/src/LlmTornado/Chat/Models/ChatModel.cs
@@ -396,6 +396,52 @@ public class ChatModel : ModelBase
         return null;
     }
 
+    /// <summary>
+    /// Returns the latest model of the given performance tier for the given provider,
+    /// or null when the provider has no latest-tier mapping yet.
+    /// </summary>
+    /// <param name="provider">The provider to get the latest model for.</param>
+    /// <param name="performance">The performance tier.</param>
+    public static ChatModel? GetLatest(LLmProviders provider, ChatModelPerformance performance)
+    {
+        return provider switch
+        {
+            LLmProviders.OpenAi => performance switch
+            {
+                ChatModelPerformance.Max => ChatModelOpenAiLatest.ModelMax,
+                ChatModelPerformance.Large => ChatModelOpenAiLatest.ModelLarge,
+                ChatModelPerformance.Medium => ChatModelOpenAiLatest.ModelMedium,
+                ChatModelPerformance.Small => ChatModelOpenAiLatest.ModelSmall,
+                _ => null
+            },
+            LLmProviders.Anthropic => performance switch
+            {
+                ChatModelPerformance.Max => ChatModelAnthropicLatest.ModelMax,
+                ChatModelPerformance.Large => ChatModelAnthropicLatest.ModelLarge,
+                ChatModelPerformance.Medium => ChatModelAnthropicLatest.ModelMedium,
+                ChatModelPerformance.Small => ChatModelAnthropicLatest.ModelSmall,
+                _ => null
+            },
+            LLmProviders.Google => performance switch
+            {
+                ChatModelPerformance.Max => ChatModelGoogleLatest.ModelMax,
+                ChatModelPerformance.Large => ChatModelGoogleLatest.ModelLarge,
+                ChatModelPerformance.Medium => ChatModelGoogleLatest.ModelMedium,
+                ChatModelPerformance.Small => ChatModelGoogleLatest.ModelSmall,
+                _ => null
+            },
+            LLmProviders.XAi => performance switch
+            {
+                ChatModelPerformance.Max => ChatModelXAiLatest.ModelMax,
+                ChatModelPerformance.Large => ChatModelXAiLatest.ModelLarge,
+                ChatModelPerformance.Medium => ChatModelXAiLatest.ModelMedium,
+                ChatModelPerformance.Small => ChatModelXAiLatest.ModelSmall,
+                _ => null
+            },
+            _ => null
+        };
+    }
+
     internal static ChatModel? ResolveModel(LLmProviders provider, string modelName)
     {
         if (modelsByProviderName.Value.TryGetValue(provider, out ChatModelVendorMap? map))

--- a/src/LlmTornado/Chat/Models/ChatModelPerformance.cs
+++ b/src/LlmTornado/Chat/Models/ChatModelPerformance.cs
@@ -1,0 +1,27 @@
+namespace LlmTornado.Chat.Models;
+
+/// <summary>
+/// Relative performance tier of a "latest" model pointer.
+/// </summary>
+public enum ChatModelPerformance
+{
+    /// <summary>
+    /// Absolute top-end tier (pro/extended-compute models); slowest and most expensive.
+    /// </summary>
+    Max,
+
+    /// <summary>
+    /// Flagship / frontier tier.
+    /// </summary>
+    Large,
+
+    /// <summary>
+    /// Balanced intelligence/cost tier.
+    /// </summary>
+    Medium,
+
+    /// <summary>
+    /// Cheap, fast, high-volume tier.
+    /// </summary>
+    Small
+}

--- a/src/LlmTornado/Chat/Models/Google/ChatModelGoogle.cs
+++ b/src/LlmTornado/Chat/Models/Google/ChatModelGoogle.cs
@@ -13,7 +13,12 @@ public class ChatModelGoogle : BaseVendorModelProvider
 {
     /// <inheritdoc cref="BaseVendorModelProvider.Provider"/>
     public override LLmProviders Provider => LLmProviders.Google;
-    
+
+    /// <summary>
+    /// Latest models by performance tier (Max/Large/Medium/Small). Pointers repointed as newer models release.
+    /// </summary>
+    public readonly ChatModelGoogleLatest Latest = new ChatModelGoogleLatest();
+
     /// <summary>
     /// Gemini models.
     /// </summary>

--- a/src/LlmTornado/Chat/Models/Google/ChatModelGoogleLatest.cs
+++ b/src/LlmTornado/Chat/Models/Google/ChatModelGoogleLatest.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using LlmTornado.Code.Models;
+
+namespace LlmTornado.Chat.Models;
+
+/// <summary>
+/// Latest models from Google by performance tier. These are pointers to existing models, repointed to newer models
+/// as they release; pin a concrete snapshot (e.g. <see cref="ChatModelGoogleGemini.Gemini35Flash"/>) if you need a stable model.
+/// </summary>
+public class ChatModelGoogleLatest : IVendorModelClassProvider
+{
+    /// <summary>
+    /// Absolute top-end tier. Google currently ships no API model above the Pro tier (no Ultra/Deep Think slug),
+    /// so Max points to the same model as <see cref="ModelLarge"/>; it will be split out when such a model releases.
+    /// Currently <c>gemini-3.1-pro-preview</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMax = ChatModelGoogleGeminiPreview.ModelGemini31ProPreview;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMax"/>
+    /// </summary>
+    public readonly ChatModel Max = ModelMax;
+
+    /// <summary>
+    /// Flagship / frontier tier. Currently <c>gemini-3.1-pro-preview</c> — no stable Gemini-3-class Pro exists yet.
+    /// </summary>
+    public static readonly ChatModel ModelLarge = ChatModelGoogleGeminiPreview.ModelGemini31ProPreview;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelLarge"/>
+    /// </summary>
+    public readonly ChatModel Large = ModelLarge;
+
+    /// <summary>
+    /// Balanced intelligence/cost tier. Currently <c>gemini-3.5-flash</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMedium = ChatModelGoogleGemini.ModelGemini35Flash;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMedium"/>
+    /// </summary>
+    public readonly ChatModel Medium = ModelMedium;
+
+    /// <summary>
+    /// Cheap, fast, high-volume tier. Currently <c>gemini-3.1-flash-lite</c>.
+    /// </summary>
+    public static readonly ChatModel ModelSmall = ChatModelGoogleGemini.ModelGemini31FlashLite;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelSmall"/>
+    /// </summary>
+    public readonly ChatModel Small = ModelSmall;
+
+    /// <summary>
+    /// Models currently pointed to by the latest tiers of Google.
+    /// </summary>
+    public static List<IModel> ModelsAll => LazyModelsAll.Value;
+
+    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [
+        ModelMax, ModelMedium, ModelSmall
+    ]);
+
+    /// <summary>
+    /// <inheritdoc cref="ModelsAll"/>
+    /// </summary>
+    public List<IModel> AllModels => ModelsAll;
+
+    internal ChatModelGoogleLatest()
+    {
+
+    }
+}

--- a/src/LlmTornado/Chat/Models/OpenAi/ChatModelOpenAi.cs
+++ b/src/LlmTornado/Chat/Models/OpenAi/ChatModelOpenAi.cs
@@ -13,7 +13,12 @@ public class ChatModelOpenAi : BaseVendorModelProvider
 {
     /// <inheritdoc cref="BaseVendorModelProvider.Provider"/>
     public override LLmProviders Provider => LLmProviders.OpenAi;
-    
+
+    /// <summary>
+    /// Latest models by performance tier (Max/Large/Medium/Small). Pointers repointed as newer models release.
+    /// </summary>
+    public readonly ChatModelOpenAiLatest Latest = new ChatModelOpenAiLatest();
+
     /// <summary>
     /// GPT 3.5 (Turbo) models.
     /// </summary>

--- a/src/LlmTornado/Chat/Models/OpenAi/ChatModelOpenAiLatest.cs
+++ b/src/LlmTornado/Chat/Models/OpenAi/ChatModelOpenAiLatest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using LlmTornado.Code.Models;
+
+namespace LlmTornado.Chat.Models;
+
+/// <summary>
+/// Latest models from OpenAI by performance tier. These are pointers to existing models, repointed to newer models
+/// as they release; pin a concrete snapshot (e.g. <see cref="ChatModelOpenAiGpt56.V56Sol"/>) if you need a stable model.
+/// </summary>
+public class ChatModelOpenAiLatest : IVendorModelClassProvider
+{
+    /// <summary>
+    /// Absolute top-end tier; slowest and most expensive. Currently <c>gpt-5.5-pro</c> — the newest dedicated pro
+    /// slug, as GPT-5.6's pro mode is a request setting (<c>reasoning.mode: "pro"</c>), not a separate model.
+    /// </summary>
+    public static readonly ChatModel ModelMax = ChatModelOpenAiGpt55.ModelV55Pro;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMax"/>
+    /// </summary>
+    public readonly ChatModel Max = ModelMax;
+
+    /// <summary>
+    /// Flagship / frontier tier. Currently <c>gpt-5.6-sol</c>.
+    /// </summary>
+    public static readonly ChatModel ModelLarge = ChatModelOpenAiGpt56.ModelV56Sol;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelLarge"/>
+    /// </summary>
+    public readonly ChatModel Large = ModelLarge;
+
+    /// <summary>
+    /// Balanced intelligence/cost tier. Currently <c>gpt-5.6-terra</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMedium = ChatModelOpenAiGpt56.ModelV56Terra;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMedium"/>
+    /// </summary>
+    public readonly ChatModel Medium = ModelMedium;
+
+    /// <summary>
+    /// Cheap, fast, high-volume tier. Currently <c>gpt-5.6-luna</c>.
+    /// </summary>
+    public static readonly ChatModel ModelSmall = ChatModelOpenAiGpt56.ModelV56Luna;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelSmall"/>
+    /// </summary>
+    public readonly ChatModel Small = ModelSmall;
+
+    /// <summary>
+    /// Models currently pointed to by the latest tiers of OpenAI.
+    /// </summary>
+    public static List<IModel> ModelsAll => LazyModelsAll.Value;
+
+    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [
+        ModelMax, ModelLarge, ModelMedium, ModelSmall
+    ]);
+
+    /// <summary>
+    /// <inheritdoc cref="ModelsAll"/>
+    /// </summary>
+    public List<IModel> AllModels => ModelsAll;
+
+    internal ChatModelOpenAiLatest()
+    {
+
+    }
+}

--- a/src/LlmTornado/Chat/Models/XAi/ChatModelXAi.cs
+++ b/src/LlmTornado/Chat/Models/XAi/ChatModelXAi.cs
@@ -12,7 +12,12 @@ public class ChatModelXAi : BaseVendorModelProvider
 {
     /// <inheritdoc cref="BaseVendorModelProvider.Provider"/>
     public override LLmProviders Provider => LLmProviders.XAi;
-    
+
+    /// <summary>
+    /// Latest models by performance tier (Max/Large/Medium/Small). Pointers repointed as newer models release.
+    /// </summary>
+    public readonly ChatModelXAiLatest Latest = new ChatModelXAiLatest();
+
     /// <summary>
     /// Grok Build models.
     /// </summary>

--- a/src/LlmTornado/Chat/Models/XAi/ChatModelXAiLatest.cs
+++ b/src/LlmTornado/Chat/Models/XAi/ChatModelXAiLatest.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using LlmTornado.Code.Models;
+
+namespace LlmTornado.Chat.Models.XAi;
+
+/// <summary>
+/// Latest models from xAI by performance tier. These are pointers to existing models, repointed to newer models
+/// as they release; pin a concrete snapshot (e.g. <see cref="ChatModelXAiGrok45.V45"/>) if you need a stable model.
+/// </summary>
+public class ChatModelXAiLatest : IVendorModelClassProvider
+{
+    /// <summary>
+    /// Absolute top-end tier. xAI currently ships no API model above the flagship tier (no Heavy slug),
+    /// so Max points to the same model as <see cref="ModelLarge"/>; it will be split out when such a model releases.
+    /// Currently <c>grok-4.5</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMax = ChatModelXAiGrok45.ModelV45;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMax"/>
+    /// </summary>
+    public readonly ChatModel Max = ModelMax;
+
+    /// <summary>
+    /// Flagship / frontier tier. Currently <c>grok-4.5</c>.
+    /// </summary>
+    public static readonly ChatModel ModelLarge = ChatModelXAiGrok45.ModelV45;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelLarge"/>
+    /// </summary>
+    public readonly ChatModel Large = ModelLarge;
+
+    /// <summary>
+    /// Balanced intelligence/cost tier. Currently <c>grok-4-1-fast-reasoning</c>.
+    /// </summary>
+    public static readonly ChatModel ModelMedium = ChatModelXAiGrok41.ModelV41FastReasoning;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelMedium"/>
+    /// </summary>
+    public readonly ChatModel Medium = ModelMedium;
+
+    /// <summary>
+    /// Cheap, fast, high-volume tier. Currently <c>grok-4-1-fast-non-reasoning</c>.
+    /// </summary>
+    public static readonly ChatModel ModelSmall = ChatModelXAiGrok41.ModelV41FastNonReasoning;
+
+    /// <summary>
+    /// <inheritdoc cref="ModelSmall"/>
+    /// </summary>
+    public readonly ChatModel Small = ModelSmall;
+
+    /// <summary>
+    /// Models currently pointed to by the latest tiers of xAI.
+    /// </summary>
+    public static List<IModel> ModelsAll => LazyModelsAll.Value;
+
+    private static readonly Lazy<List<IModel>> LazyModelsAll = new Lazy<List<IModel>>(() => [
+        ModelMax, ModelMedium, ModelSmall
+    ]);
+
+    /// <summary>
+    /// <inheritdoc cref="ModelsAll"/>
+    /// </summary>
+    public List<IModel> AllModels => ModelsAll;
+
+    internal ChatModelXAiLatest()
+    {
+
+    }
+}


### PR DESCRIPTION
This pull request introduces a new abstraction for accessing the "latest" chat models by performance tier (Max, Large, Medium, Small) across all major providers (OpenAI, Anthropic, Google, xAI). This makes it easier to reference the most current, recommended models for each tier, and provides a single place to update these pointers as new models are released. It also adds a new enum for performance tiers and a utility method to fetch the latest model for any provider/tier combination.

Key changes:

### Abstraction for Latest Model Pointers

* Added new `Latest` properties to `ChatModelOpenAi`, `ChatModelAnthropic`, `ChatModelGoogle`, and `ChatModelXAi` classes, each exposing a vendor-specific class (`ChatModelOpenAiLatest`, etc.) that holds references to the latest models by tier. [[1]](diffhunk://#diff-a616a8cb0d9f18b98a1078476cea244752fa1a6b86633282ae2f9508885581bfR17-R21) [[2]](diffhunk://#diff-6fb1c075cd0ac06d2ed86dcb956d3bf15cb5d82e90b1e3c9439534dd94b5cf2bR14-R18) [[3]](diffhunk://#diff-d51a982caa03c5facced43006498ff5df193ae855748a38136fe043208d1e12bR17-R21) [[4]](diffhunk://#diff-55a71b5c39b1e18aee5b2c4ade66944941e37e5c0131859cf9911bacd55df4a5R16-R20)
* Implemented the new latest model classes for each provider, encapsulating static and instance properties for each tier (Max, Large, Medium, Small), and providing an `AllModels` list for convenience. [[1]](diffhunk://#diff-ad2c84cd4d29ea8752e068d604b2458a7bb6462d05bfd94eef8411ac490ea948R1-R72) [[2]](diffhunk://#diff-7a21bba54cf11af2f2c96a31a5a79f3b7303cb4b5a210a234d37b8ee9510bf9fR1-R71) [[3]](diffhunk://#diff-43a178a9342932015d36645f24696770f858982aaca51556e5237b01389b7f66R1-R73) [[4]](diffhunk://#diff-315f451e74cbf30ed6b107b4612795c78f1851532501d594fd7f1f9ee7cabb11R1-R73)

### Performance Tier Abstraction

* Introduced the `ChatModelPerformance` enum to standardize performance tiers across providers.

### Utility for Fetching Latest Models

* Added the static method `ChatModel.GetLatest` to retrieve the latest model for a given provider and performance tier, centralizing tier-to-model resolution logic.

These changes make it much simpler to always reference the current best model for a given use case, and will reduce maintenance effort when new models are released.