### PR TITLE
fix: Google reasoning text leaking into plaintext content

### DIFF
--- a/src/LlmTornado.Tests/GoogleReasoningPartTests.cs
+++ b/src/LlmTornado.Tests/GoogleReasoningPartTests.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using LlmTornado.Chat;
+using LlmTornado.Chat.Vendors.Google;
+
+namespace LlmTornado.Tests;
+
+/// <summary>
+/// Regression tests for the Google/Gemini/Gemma vendor part mapper. Does not require API credentials.
+/// </summary>
+[TestFixture]
+public class GoogleReasoningPartTests
+{
+    [Test]
+    public void ThoughtPart_WithText_IsClassifiedAsReasoning_AndNotAppendedToPlaintext()
+    {
+        VendorGoogleChatRequestMessagePart part = new VendorGoogleChatRequestMessagePart
+        {
+            Text = "the model is thinking about the answer",
+            Thought = true
+        };
+
+        StringBuilder sb = new StringBuilder();
+        ChatMessagePart result = part.ToMessagePart(sb);
+
+        Assert.That(result.Type, Is.EqualTo(ChatMessageTypes.Reasoning));
+        Assert.That(result.Reasoning?.Content, Is.EqualTo("the model is thinking about the answer"));
+
+        // The bug: sb (which becomes ChatMessage.Content / the streamed "content" field)
+        // used to receive the thought text unconditionally, mixing reasoning into the
+        // user-visible answer even though the part was correctly flagged as a thought.
+        Assert.That(sb.ToString(), Is.Empty);
+    }
+
+    [Test]
+    public void NonThoughtPart_WithText_IsClassifiedAsText_AndAppendedToPlaintext()
+    {
+        VendorGoogleChatRequestMessagePart part = new VendorGoogleChatRequestMessagePart
+        {
+            Text = "42",
+            Thought = false
+        };
+
+        StringBuilder sb = new StringBuilder();
+        ChatMessagePart result = part.ToMessagePart(sb);
+
+        Assert.That(result.Type, Is.EqualTo(ChatMessageTypes.Text));
+        Assert.That(result.Text, Is.EqualTo("42"));
+        Assert.That(sb.ToString(), Is.EqualTo("42"));
+    }
+
+    [Test]
+    public void ThoughtPart_WithoutText_StillReportsReasoningSignature()
+    {
+        // Redacted-thought blocks: content can be empty while a signature is still present.
+        VendorGoogleChatRequestMessagePart part = new VendorGoogleChatRequestMessagePart
+        {
+            Text = null,
+            Thought = true,
+            ThoughtSignature = "opaque-signature"
+        };
+
+        StringBuilder sb = new StringBuilder();
+        ChatMessagePart result = part.ToMessagePart(sb);
+
+        Assert.That(result.Type, Is.EqualTo(ChatMessageTypes.Reasoning));
+        Assert.That(result.Reasoning?.Signature, Is.EqualTo("opaque-signature"));
+        Assert.That(sb.ToString(), Is.Empty);
+    }
+}

--- a/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
+++ b/src/LlmTornado/Chat/Vendors/Google/VendorGoogleChatRequest.cs
@@ -543,9 +543,22 @@ internal class VendorGoogleChatRequestMessagePart
         }
         else if (Text is not null)
         {
-            part.Type = ChatMessageTypes.Text;
-            part.Text = Text;
-            sb.Append(Text);
+            if (Thought ?? false)
+            {
+                part.Type = ChatMessageTypes.Reasoning;
+                part.Reasoning = new ChatMessageReasoningData
+                {
+                    Provider = LLmProviders.Google,
+                    Content = Text,
+                    Signature = ThoughtSignature
+                };
+            }
+            else
+            {
+                part.Type = ChatMessageTypes.Text;
+                part.Text = Text;
+                sb.Append(Text);
+            }
         }
         else if (InlineData is not null)
         {


### PR DESCRIPTION
## Bug

`VendorGoogleChatRequestMessagePart.ToMessagePart()` has two independent `if`/`else if` chains. The first classifies a part as `Text` and appends its text to the plaintext `StringBuilder` whenever `Text` is non-null, with no regard for the `Thought` flag:

```csharp
else if (Text is not null)
{
    part.Type = ChatMessageTypes.Text;
    part.Text = Text;
    sb.Append(Text);
}
```

A second, separate chain then correctly overwrites `part.Type` back to `Reasoning` when `Thought` is true:

```csharp
else if (Thought ?? false)
{
    part.Type = ChatMessageTypes.Reasoning;
    part.Reasoning = new ChatMessageReasoningData { ... };
}
```

...but by the time this runs, the thought text has already been unconditionally appended to the `StringBuilder` that becomes `ChatMessage.Content`.

**Net effect:** for any Google/Gemini/Gemma response where a part carries both `Text` and `Thought=true` — i.e. virtually every "thinking" response — `part.Type`/`part.Reasoning` end up correct, but `Content` is polluted with the model's reasoning mixed into what should be plaintext-only output. This affects both the streaming path (each per-chunk `ChatResult.Delta`) and the non-streaming path (`ChatResult.Choices[0].Message`), since both go through `ToChatMessage` → `ToMessagePart`.

Consumers reading `ChatMessage.Content`/`Delta.Content` directly (the common case for OpenAI-compatible proxies) see the entire chain-of-thought dumped into the answer, with no way to distinguish it from the real output — even though `Delta.Parts` is individually well-typed.

## Fix

Check the `Thought` flag before deciding whether to append to the `StringBuilder`, so thought-flagged text is only ever recorded on `part.Reasoning`, never mixed into the plaintext accumulator:

```csharp
else if (Text is not null)
{
    if (Thought ?? false)
    {
        part.Type = ChatMessageTypes.Reasoning;
        part.Reasoning = new ChatMessageReasoningData
        {
            Provider = LLmProviders.Google,
            Content = Text,
            Signature = ThoughtSignature
        };
    }
    else
    {
        part.Type = ChatMessageTypes.Text;
        part.Text = Text;
        sb.Append(Text);
    }
}
```

The second chain's `Thought` branch is left in place — it's still needed for the text-less "redacted reasoning" case (content empty, signature present) it was already meant to cover; it just becomes a harmless no-op re-assignment in the text+thought case, since the first chain now handles it correctly.

## Testing

Added `GoogleReasoningPartTests.cs` — three focused, credential-free unit tests directly exercising `ToMessagePart`:
- `Thought=true` + `Text` set → `Type == Reasoning`, `Reasoning.Content` populated, `StringBuilder` stays empty (previously failed: `StringBuilder` was polluted).
- `Thought=false` + `Text` set → `Type == Text`, `StringBuilder` gets the text (unchanged, confirms no regression).
- `Thought=true` + `Text == null` (redacted block) → `Type == Reasoning`, signature preserved (unchanged, confirms the second chain still covers this case).

Also verified via a standalone reflection harness against the built DLL, exercising the exact before/after behavior described above.

## Context

Found while debugging why an OpenAI-compatible proxy built on this SDK couldn't cleanly separate Gemma 4's thinking output from its final answer during streaming — every "thinking" turn showed the raw chain-of-thought as if it were the response.