### PR TITLE
(feat)Add ChatGPT subscription authentication for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,76 +131,7 @@ foreach (ChatModel model in models)
 
 ### OpenAI API keys and Codex subscriptions
 
-OpenAI API access continues to use an API key and supports the normal text and image endpoints:
-
-```csharp
-TornadoApi api = new TornadoApi(LLmProviders.OpenAi, Environment.GetEnvironmentVariable("OPENAI_API_KEY")!);
-string? response = await api.Chat.CreateConversation(ChatModel.OpenAi.Gpt5.Mini)
-    .AppendUserInput("Summarize this text.")
-    .GetResponse();
-```
-
-ChatGPT Plus, Pro, Business, Edu, and Enterprise Codex access has its own model catalog and text-only thread API; it does not expose Tornado's image-generation endpoints.
-
-The official local Codex app-server can own login, token persistence, refresh, and agent execution:
-
-```csharp
-TornadoApi api = new TornadoApi();
-await using CodexSession codex = await api.Codex.ConnectAsync();
-
-CodexAccountResult account = await codex.GetAccountAsync();
-if (account.Account is null)
-{
-    CodexBrowserLogin login = await codex.StartBrowserLoginAsync();
-    Process.Start(new ProcessStartInfo(login.AuthorizationUrl.AbsoluteUri) { UseShellExecute = true });
-
-    CodexLoginResult loginResult = await login.WaitAsync();
-    if (!loginResult.Success)
-    {
-        throw new InvalidOperationException(loginResult.Error);
-    }
-}
-
-IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
-CodexModel model = models.First(x => x.IsDefault);
-CodexThread thread = await codex.StartThreadAsync(new CodexThreadOptions { Model = model.Model });
-CodexTurnResult turn = await thread.RunAsync("Explain the current project in three sentences.");
-
-Console.WriteLine(turn.FinalResponse);
-```
-
-The Codex executable must be installed and available on `PATH`, or supplied through `CodexAppServerOptions.ExecutablePath`. Codex owns OAuth token storage and refresh; LLMTornado never receives or persists the ChatGPT refresh token.
-
-Alternatively, LLMTornado can perform browser OAuth and token refresh directly without a Codex installation:
-
-```csharp
-TornadoApi api = new TornadoApi();
-await using CodexOAuthSession codex = await api.Codex.ConnectOAuthAsync();
-
-CodexAccountResult account = await codex.GetAccountAsync();
-if (account.Account is null)
-{
-    CodexOAuthBrowserLogin login = await codex.StartBrowserLoginAsync();
-    Process.Start(new ProcessStartInfo(login.AuthorizationUrl.AbsoluteUri) { UseShellExecute = true });
-
-    CodexOAuthLoginResult loginResult = await login.WaitAsync();
-    if (!loginResult.Success)
-    {
-        throw new InvalidOperationException(loginResult.Error);
-    }
-}
-
-IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
-CodexOAuthThread thread = await codex.StartThreadAsync(new CodexOAuthThreadOptions
-{
-    Model = models.First(x => x.IsDefault).Model
-});
-CodexOAuthTurnResult turn = await thread.RunAsync("Explain the current project in three sentences.");
-
-Console.WriteLine(turn.FinalResponse);
-```
-
-The direct variant uses OAuth2 PKCE with an `auth.openai.com` browser callback. Rotating refresh tokens are stored through `ICodexOAuthCredentialStore`; the default file store writes to the current user's local application data, and applications can provide a different store.
+OpenAI API keys continue to support normal text and image models, while ChatGPT subscription access for Codex is explained in the [Codex guide](src/LlmTornado/Codex/README.md).
 
 ## ❄️ Vendor Extensions
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,79 @@ foreach (ChatModel model in models)
 
 💡 Instead of passing in a strongly typed model, you can pass a string instead: `await api.Chat.CreateConversation("gpt-5-mini")`, Tornado will automatically resolve the provider.
 
+### OpenAI API keys and Codex subscriptions
+
+OpenAI API access continues to use an API key and supports the normal text and image endpoints:
+
+```csharp
+TornadoApi api = new TornadoApi(LLmProviders.OpenAi, Environment.GetEnvironmentVariable("OPENAI_API_KEY")!);
+string? response = await api.Chat.CreateConversation(ChatModel.OpenAi.Gpt5.Mini)
+    .AppendUserInput("Summarize this text.")
+    .GetResponse();
+```
+
+ChatGPT Plus, Pro, Business, Edu, and Enterprise Codex access has its own model catalog and text-only thread API; it does not expose Tornado's image-generation endpoints.
+
+The official local Codex app-server can own login, token persistence, refresh, and agent execution:
+
+```csharp
+TornadoApi api = new TornadoApi();
+await using CodexSession codex = await api.Codex.ConnectAsync();
+
+CodexAccountResult account = await codex.GetAccountAsync();
+if (account.Account is null)
+{
+    CodexBrowserLogin login = await codex.StartBrowserLoginAsync();
+    Process.Start(new ProcessStartInfo(login.AuthorizationUrl.AbsoluteUri) { UseShellExecute = true });
+
+    CodexLoginResult loginResult = await login.WaitAsync();
+    if (!loginResult.Success)
+    {
+        throw new InvalidOperationException(loginResult.Error);
+    }
+}
+
+IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
+CodexModel model = models.First(x => x.IsDefault);
+CodexThread thread = await codex.StartThreadAsync(new CodexThreadOptions { Model = model.Model });
+CodexTurnResult turn = await thread.RunAsync("Explain the current project in three sentences.");
+
+Console.WriteLine(turn.FinalResponse);
+```
+
+The Codex executable must be installed and available on `PATH`, or supplied through `CodexAppServerOptions.ExecutablePath`. Codex owns OAuth token storage and refresh; LLMTornado never receives or persists the ChatGPT refresh token.
+
+Alternatively, LLMTornado can perform browser OAuth and token refresh directly without a Codex installation:
+
+```csharp
+TornadoApi api = new TornadoApi();
+await using CodexOAuthSession codex = await api.Codex.ConnectOAuthAsync();
+
+CodexAccountResult account = await codex.GetAccountAsync();
+if (account.Account is null)
+{
+    CodexOAuthBrowserLogin login = await codex.StartBrowserLoginAsync();
+    Process.Start(new ProcessStartInfo(login.AuthorizationUrl.AbsoluteUri) { UseShellExecute = true });
+
+    CodexOAuthLoginResult loginResult = await login.WaitAsync();
+    if (!loginResult.Success)
+    {
+        throw new InvalidOperationException(loginResult.Error);
+    }
+}
+
+IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
+CodexOAuthThread thread = await codex.StartThreadAsync(new CodexOAuthThreadOptions
+{
+    Model = models.First(x => x.IsDefault).Model
+});
+CodexOAuthTurnResult turn = await thread.RunAsync("Explain the current project in three sentences.");
+
+Console.WriteLine(turn.FinalResponse);
+```
+
+The direct variant uses OAuth2 PKCE with an `auth.openai.com` browser callback. Rotating refresh tokens are stored through `ICodexOAuthCredentialStore`; the default file store writes to the current user's local application data, and applications can provide a different store.
+
 ## ❄️ Vendor Extensions
 
 Tornado has a powerful concept of `VendorExtensions` which can be applied to various endpoints and are strongly typed. Many Providers offer unique/niche APIs, often enabling use cases otherwise unavailable. For example, let's set a reasoning budget for Anthropic's Claude 3.7:

--- a/src/LlmTornado.Tests/CodexOAuthTests.cs
+++ b/src/LlmTornado.Tests/CodexOAuthTests.cs
@@ -1,0 +1,386 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using LlmTornado.Codex;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Tests;
+
+[TestFixture]
+public class CodexOAuthTests
+{
+    [Test]
+    public async Task BrowserLogin_UsesPkceCallbackAndPersistsCredentials()
+    {
+        string idToken = Jwt(new JObject
+        {
+            ["email"] = "user@example.com",
+            ["https://api.openai.com/auth"] = new JObject
+            {
+                ["chatgpt_account_id"] = "account-1",
+                ["chatgpt_plan_type"] = "pro"
+            }
+        });
+        string accessToken = Jwt(new JObject
+        {
+            ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+        });
+        string? tokenRequestBody = null;
+        RecordingHandler handler = new RecordingHandler(async request =>
+        {
+            tokenRequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync();
+            return JsonResponse(new JObject
+            {
+                ["id_token"] = idToken,
+                ["access_token"] = accessToken,
+                ["refresh_token"] = "refresh-1"
+            });
+        });
+        CodexOAuthMemoryCredentialStore store = new CodexOAuthMemoryCredentialStore();
+
+        await using CodexOAuthSession session = await new TornadoApi().Codex.ConnectOAuthAsync(
+            new CodexOAuthOptions
+            {
+                CallbackPort = 0,
+                FallbackCallbackPort = 0,
+                CredentialStore = store,
+                HttpClient = new HttpClient(handler)
+            });
+        CodexOAuthBrowserLogin login = await session.StartBrowserLoginAsync();
+        Dictionary<string, string> authorizeQuery = CodexOAuthProtocol.ParseQuery(login.AuthorizationUrl.Query);
+        Uri callback = new Uri(
+            $"http://localhost:{login.CallbackPort}/auth/callback" +
+            $"?code=test-code&state={Uri.EscapeDataString(authorizeQuery["state"])}");
+
+        using HttpClient callbackClient = new HttpClient();
+        using HttpResponseMessage callbackResponse = await callbackClient.GetAsync(callback);
+        CodexOAuthLoginResult result = await login.WaitAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(callbackResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Account?.Email, Is.EqualTo("user@example.com"));
+            Assert.That(result.Account?.PlanType, Is.EqualTo("pro"));
+            Assert.That(authorizeQuery["client_id"], Is.EqualTo("app_EMoamEEZ73f0CkXaXp7hrann"));
+            Assert.That(authorizeQuery["code_challenge_method"], Is.EqualTo("S256"));
+        });
+
+        Dictionary<string, string> tokenForm = CodexOAuthProtocol.ParseQuery(tokenRequestBody ?? string.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(tokenForm["grant_type"], Is.EqualTo("authorization_code"));
+            Assert.That(tokenForm["code"], Is.EqualTo("test-code"));
+            Assert.That(
+                CodexOAuthProtocol.CreateCodeChallenge(tokenForm["code_verifier"]),
+                Is.EqualTo(authorizeQuery["code_challenge"]));
+        });
+
+        CodexOAuthCredentials? saved = await store.LoadAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(saved?.AccessToken, Is.EqualTo(accessToken));
+            Assert.That(saved?.RefreshToken, Is.EqualTo("refresh-1"));
+            Assert.That(saved?.AccountId, Is.EqualTo("account-1"));
+        });
+    }
+
+    [Test]
+    public async Task ListModels_RefreshesRotatingTokenAndPreservesCatalogOrder()
+    {
+        CodexOAuthMemoryCredentialStore store = new CodexOAuthMemoryCredentialStore(
+            Credentials("expired-access", "refresh-old", DateTimeOffset.UtcNow.AddMinutes(-1)));
+        int refreshRequests = 0;
+        string? modelAuthorization = null;
+        string? modelAccount = null;
+        RecordingHandler handler = new RecordingHandler(async request =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/oauth/token", StringComparison.Ordinal) == true)
+            {
+                refreshRequests++;
+                JObject refresh = JObject.Parse(await request.Content!.ReadAsStringAsync());
+                Assert.That(refresh.Value<string>("refresh_token"), Is.EqualTo("refresh-old"));
+                return JsonResponse(new JObject
+                {
+                    ["access_token"] = Jwt(new JObject
+                    {
+                        ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+                    }),
+                    ["refresh_token"] = "refresh-new"
+                });
+            }
+
+            modelAuthorization = request.Headers.Authorization?.ToString();
+            modelAccount = request.Headers.TryGetValues("ChatGPT-Account-ID", out IEnumerable<string>? values)
+                ? values.Single()
+                : null;
+            return JsonResponse(new JObject
+            {
+                ["models"] = new JArray
+                {
+                    BackendModel("gpt-5.4", true, "low", "medium", "high"),
+                    BackendModel("gpt-5.3-codex", false, new[] { "medium", "high" }, "list"),
+                    BackendModel("hidden-model", false, "medium", visibility: "hide")
+                }
+            });
+        });
+
+        await using CodexOAuthSession session = await new TornadoApi().Codex.ConnectOAuthAsync(
+            new CodexOAuthOptions
+            {
+                CredentialStore = store,
+                HttpClient = new HttpClient(handler),
+                ClientVersion = "1.2.3"
+            });
+        IReadOnlyList<CodexModel> models = await session.ListModelsAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(refreshRequests, Is.EqualTo(1));
+            Assert.That(modelAuthorization, Does.StartWith("Bearer "));
+            Assert.That(modelAccount, Is.EqualTo("account-1"));
+            Assert.That(models.Select(model => model.Model), Is.EqualTo(new[] { "gpt-5.4", "gpt-5.3-codex" }));
+            Assert.That(
+                models[0].SupportedReasoningEfforts.Select(effort => effort.ReasoningEffort),
+                Is.EqualTo(new[] { "low", "medium", "high" }));
+        });
+
+        CodexOAuthCredentials? saved = await store.LoadAsync();
+        Assert.That(saved?.RefreshToken, Is.EqualTo("refresh-new"));
+    }
+
+    [Test]
+    public async Task TextThread_SendsOnlyTextAndReplaysClientManagedHistory()
+    {
+        CodexOAuthMemoryCredentialStore store = new CodexOAuthMemoryCredentialStore(
+            Credentials(
+                Jwt(new JObject { ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() }),
+                "refresh-1",
+                DateTimeOffset.UtcNow.AddHours(1)));
+        List<JObject> payloads = [];
+        int responseNumber = 0;
+        RecordingHandler handler = new RecordingHandler(async request =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/models", StringComparison.Ordinal) == true)
+            {
+                return JsonResponse(new JObject
+                {
+                    ["models"] = new JArray
+                    {
+                        BackendModel("gpt-5.4", true, new[] { "medium", "high" }, "list")
+                    }
+                });
+            }
+
+            payloads.Add(JObject.Parse(await request.Content!.ReadAsStringAsync()));
+            responseNumber++;
+            string responseId = $"response-{responseNumber}";
+            string sse =
+                $"event: response.output_text.delta\n" +
+                $"data: {{\"type\":\"response.output_text.delta\",\"response_id\":\"{responseId}\",\"item_id\":\"item-1\",\"delta\":\"Codex \"}}\n\n" +
+                $"event: response.output_text.delta\n" +
+                $"data: {{\"type\":\"response.output_text.delta\",\"response_id\":\"{responseId}\",\"item_id\":\"item-1\",\"delta\":\"reply\"}}\n\n" +
+                $"event: response.output_item.done\n" +
+                $"data: {{\"type\":\"response.output_item.done\",\"item\":{{\"id\":\"reasoning-{responseNumber}\",\"type\":\"reasoning\",\"encrypted_content\":\"encrypted-{responseNumber}\",\"summary\":[]}}}}\n\n" +
+                $"event: response.output_item.done\n" +
+                $"data: {{\"type\":\"response.output_item.done\",\"item\":{{\"id\":\"message-{responseNumber}\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"Codex reply\"}}]}}}}\n\n" +
+                $"event: response.completed\n" +
+                $"data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{responseId}\",\"status\":\"completed\"}}}}\n\n";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(sse, Encoding.UTF8, "text/event-stream")
+            };
+        });
+
+        await using CodexOAuthSession session = await new TornadoApi().Codex.ConnectOAuthAsync(
+            new CodexOAuthOptions
+            {
+                CredentialStore = store,
+                HttpClient = new HttpClient(handler)
+            });
+        CodexOAuthThread thread = await session.StartThreadAsync(new CodexOAuthThreadOptions
+        {
+            Model = "gpt-5.4",
+            Instructions = "Reply briefly."
+        });
+        List<string> deltas = [];
+        CodexOAuthTurnResult first = await thread.RunAsync("First", new CodexOAuthTurnOptions
+        {
+            ReasoningEffort = "high",
+            OnTextDelta = delta =>
+            {
+                deltas.Add(delta.Delta);
+                return Task.CompletedTask;
+            }
+        });
+        CodexOAuthTurnResult second = await thread.RunAsync("Second");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.FinalResponse, Is.EqualTo("Codex reply"));
+            Assert.That(second.ResponseId, Is.EqualTo("response-2"));
+            Assert.That(deltas, Is.EqualTo(new[] { "Codex ", "reply" }));
+            Assert.That(payloads[0].Value<string>("instructions"), Is.EqualTo("gpt-5.4 base instructions"));
+            Assert.That(payloads[0]["input"]?[0]?["role"]?.Value<string>(), Is.EqualTo("developer"));
+            Assert.That(payloads[0]["input"]?[1]?["content"]?[0]?["type"]?.Value<string>(), Is.EqualTo("input_text"));
+            Assert.That(payloads[0].ToString(Formatting.None), Does.Not.Contain("image"));
+            Assert.That(payloads[0]["include"]?[0]?.Value<string>(), Is.EqualTo("reasoning.encrypted_content"));
+            Assert.That(payloads[1].Property("previous_response_id"), Is.Null);
+            Assert.That(payloads[1]["input"]?.Count(), Is.EqualTo(5));
+            Assert.That(payloads[1]["input"]?[2]?["encrypted_content"]?.Value<string>(), Is.EqualTo("encrypted-1"));
+            Assert.That(payloads[1]["input"]?[3]?["role"]?.Value<string>(), Is.EqualTo("assistant"));
+            Assert.That(payloads[1]["input"]?[4]?["content"]?[0]?["text"]?.Value<string>(), Is.EqualTo("Second"));
+            Assert.That(
+                typeof(CodexOAuthSession).GetMethods().Any(method => method.Name.Contains("Image", StringComparison.Ordinal)),
+                Is.False);
+        });
+    }
+
+    [Test]
+    public async Task UnauthorizedModelRequest_RefreshesAndRetriesOnce()
+    {
+        CodexOAuthMemoryCredentialStore store = new CodexOAuthMemoryCredentialStore(
+            Credentials(
+                Jwt(new JObject { ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() }),
+                "refresh-old",
+                DateTimeOffset.UtcNow.AddHours(1)));
+        int modelRequests = 0;
+        int refreshRequests = 0;
+        RecordingHandler handler = new RecordingHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath.EndsWith("/oauth/token", StringComparison.Ordinal) == true)
+            {
+                refreshRequests++;
+                return Task.FromResult(JsonResponse(new JObject
+                {
+                    ["access_token"] = Jwt(new JObject
+                    {
+                        ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+                    }),
+                    ["refresh_token"] = "refresh-new"
+                }));
+            }
+
+            modelRequests++;
+            return Task.FromResult(modelRequests == 1
+                ? new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                : JsonResponse(new JObject
+                {
+                    ["models"] = new JArray { BackendModel("gpt-5.4", true, "medium") }
+                }));
+        });
+
+        await using CodexOAuthSession session = await new TornadoApi().Codex.ConnectOAuthAsync(
+            new CodexOAuthOptions
+            {
+                CredentialStore = store,
+                HttpClient = new HttpClient(handler)
+            });
+        IReadOnlyList<CodexModel> models = await session.ListModelsAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(models, Has.Count.EqualTo(1));
+            Assert.That(modelRequests, Is.EqualTo(2));
+            Assert.That(refreshRequests, Is.EqualTo(1));
+        });
+    }
+
+    private static CodexOAuthCredentials Credentials(
+        string accessToken,
+        string refreshToken,
+        DateTimeOffset expiresAt)
+        => new CodexOAuthCredentials
+        {
+            IdToken = Jwt(new JObject
+            {
+                ["email"] = "user@example.com",
+                ["https://api.openai.com/auth"] = new JObject
+                {
+                    ["chatgpt_account_id"] = "account-1",
+                    ["chatgpt_plan_type"] = "pro"
+                }
+            }),
+            AccessToken = accessToken,
+            RefreshToken = refreshToken,
+            AccountId = "account-1",
+            Email = "user@example.com",
+            PlanType = "pro",
+            ExpiresAtUtc = expiresAt,
+            LastRefreshUtc = DateTimeOffset.UtcNow
+        };
+
+    private static JObject BackendModel(
+        string slug,
+        bool isDefault,
+        params string[] efforts)
+        => BackendModel(slug, isDefault, efforts, "list");
+
+    private static JObject BackendModel(
+        string slug,
+        bool isDefault,
+        string effort,
+        string visibility)
+        => BackendModel(slug, isDefault, new[] { effort }, visibility);
+
+    private static JObject BackendModel(
+        string slug,
+        bool isDefault,
+        IReadOnlyList<string> efforts,
+        string visibility)
+        => new JObject
+        {
+            ["slug"] = slug,
+            ["display_name"] = slug,
+            ["description"] = $"{slug} description",
+            ["base_instructions"] = $"{slug} base instructions",
+            ["visibility"] = visibility,
+            ["show_in_picker"] = true,
+            ["supported_in_api"] = true,
+            ["is_default"] = isDefault,
+            ["default_reasoning_level"] = efforts.First(),
+            ["supported_reasoning_levels"] = new JArray(efforts.Select(effort => new JObject
+            {
+                ["effort"] = effort,
+                ["description"] = effort
+            })),
+            ["input_modalities"] = new JArray("text")
+        };
+
+    private static string Jwt(JObject claims)
+    {
+        string header = Base64Url(Encoding.UTF8.GetBytes("{}"));
+        string payload = Base64Url(Encoding.UTF8.GetBytes(claims.ToString(Formatting.None)));
+        return $"{header}.{payload}.signature";
+    }
+
+    private static string Base64Url(byte[] value)
+        => Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static HttpResponseMessage JsonResponse(JObject body)
+        => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body.ToString(Formatting.None), Encoding.UTF8, "application/json")
+        };
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> handler;
+
+        internal RecordingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        {
+            this.handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return handler(request);
+        }
+    }
+}

--- a/src/LlmTornado.Tests/CodexOAuthTests.cs
+++ b/src/LlmTornado.Tests/CodexOAuthTests.cs
@@ -96,6 +96,7 @@ public class CodexOAuthTests
         int refreshRequests = 0;
         string? modelAuthorization = null;
         string? modelAccount = null;
+        string? catalogClientVersion = null;
         RecordingHandler handler = new RecordingHandler(async request =>
         {
             if (request.RequestUri?.AbsolutePath.EndsWith("/oauth/token", StringComparison.Ordinal) == true)
@@ -117,6 +118,9 @@ public class CodexOAuthTests
             modelAccount = request.Headers.TryGetValues("ChatGPT-Account-ID", out IEnumerable<string>? values)
                 ? values.Single()
                 : null;
+            Dictionary<string, string> catalogQuery =
+                CodexOAuthProtocol.ParseQuery(request.RequestUri?.Query ?? string.Empty);
+            catalogQuery.TryGetValue("client_version", out catalogClientVersion);
             return JsonResponse(new JObject
             {
                 ["models"] = new JArray
@@ -142,14 +146,50 @@ public class CodexOAuthTests
             Assert.That(refreshRequests, Is.EqualTo(1));
             Assert.That(modelAuthorization, Does.StartWith("Bearer "));
             Assert.That(modelAccount, Is.EqualTo("account-1"));
+            Assert.That(catalogClientVersion, Is.EqualTo(CodexOAuthOptions.DefaultCodexProtocolVersion));
+            Assert.That(catalogClientVersion, Is.Not.EqualTo("1.2.3"));
             Assert.That(models.Select(model => model.Model), Is.EqualTo(new[] { "gpt-5.4", "gpt-5.3-codex" }));
             Assert.That(
                 models[0].SupportedReasoningEfforts.Select(effort => effort.ReasoningEffort),
                 Is.EqualTo(new[] { "low", "medium", "high" }));
+            Assert.That(
+                models[0].ServiceTiers.Select(serviceTier => serviceTier.Id),
+                Is.EqualTo(new[] { "priority", "future-tier" }));
+            Assert.That(models[0].DefaultServiceTier, Is.EqualTo("priority"));
         });
 
         CodexOAuthCredentials? saved = await store.LoadAsync();
         Assert.That(saved?.RefreshToken, Is.EqualTo("refresh-new"));
+    }
+
+    [Test]
+    public async Task ListModels_UsesConfiguredCodexProtocolVersion()
+    {
+        CodexOAuthMemoryCredentialStore store = new CodexOAuthMemoryCredentialStore(
+            Credentials(
+                Jwt(new JObject { ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() }),
+                "refresh-1",
+                DateTimeOffset.UtcNow.AddHours(1)));
+        string? catalogClientVersion = null;
+        RecordingHandler handler = new RecordingHandler(request =>
+        {
+            Dictionary<string, string> query =
+                CodexOAuthProtocol.ParseQuery(request.RequestUri?.Query ?? string.Empty);
+            query.TryGetValue("client_version", out catalogClientVersion);
+            return Task.FromResult(JsonResponse(new JObject { ["models"] = new JArray() }));
+        });
+
+        await using CodexOAuthSession session = await new TornadoApi().Codex.ConnectOAuthAsync(
+            new CodexOAuthOptions
+            {
+                CredentialStore = store,
+                HttpClient = new HttpClient(handler),
+                ClientVersion = "1.2.3",
+                CodexProtocolVersion = "0.147.1-test"
+            });
+        await session.ListModelsAsync();
+
+        Assert.That(catalogClientVersion, Is.EqualTo("0.147.1-test"));
     }
 
     [Test]
@@ -210,6 +250,7 @@ public class CodexOAuthTests
         CodexOAuthTurnResult first = await thread.RunAsync("First", new CodexOAuthTurnOptions
         {
             ReasoningEffort = "high",
+            ServiceTier = "priority",
             OnTextDelta = delta =>
             {
                 deltas.Add(delta.Delta);
@@ -228,6 +269,7 @@ public class CodexOAuthTests
             Assert.That(payloads[0]["input"]?[1]?["content"]?[0]?["type"]?.Value<string>(), Is.EqualTo("input_text"));
             Assert.That(payloads[0].ToString(Formatting.None), Does.Not.Contain("image"));
             Assert.That(payloads[0]["include"]?[0]?.Value<string>(), Is.EqualTo("reasoning.encrypted_content"));
+            Assert.That(payloads[0].Value<string>("service_tier"), Is.EqualTo("priority"));
             Assert.That(payloads[1].Property("previous_response_id"), Is.Null);
             Assert.That(payloads[1]["input"]?.Count(), Is.EqualTo(5));
             Assert.That(payloads[1]["input"]?[2]?["encrypted_content"]?.Value<string>(), Is.EqualTo("encrypted-1"));
@@ -342,11 +384,23 @@ public class CodexOAuthTests
             ["supported_in_api"] = true,
             ["is_default"] = isDefault,
             ["default_reasoning_level"] = efforts.First(),
+            ["default_service_tier"] = "priority",
             ["supported_reasoning_levels"] = new JArray(efforts.Select(effort => new JObject
             {
                 ["effort"] = effort,
                 ["description"] = effort
             })),
+            ["service_tiers"] = new JArray(new JObject
+            {
+                ["id"] = "priority",
+                ["name"] = "Fast",
+                ["description"] = "1.5x speed"
+            }, new JObject
+            {
+                ["id"] = "future-tier",
+                ["name"] = "Future",
+                ["description"] = "Future catalog value"
+            }),
             ["input_modalities"] = new JArray("text")
         };
 

--- a/src/LlmTornado.Tests/CodexTests.cs
+++ b/src/LlmTornado.Tests/CodexTests.cs
@@ -31,6 +31,10 @@ public class CodexTests
         Assert.That(
             models[0].SupportedReasoningEfforts.Select(x => x.ReasoningEffort),
             Is.EqualTo(new[] { "low", "medium", "high" }));
+        Assert.That(
+            models[0].ServiceTiers.Select(x => x.Id),
+            Is.EqualTo(new[] { "priority", "future-tier" }));
+        Assert.That(models[0].DefaultServiceTier, Is.EqualTo("priority"));
 
         CodexThread thread = await session.StartThreadAsync(new CodexThreadOptions
         {
@@ -41,6 +45,7 @@ public class CodexTests
         CodexTurnResult turn = await thread.RunAsync("Reply briefly.", new CodexTurnOptions
         {
             ReasoningEffort = "high",
+            ServiceTier = "priority",
             OnTextDelta = delta =>
             {
                 deltas.Add(delta.Delta);
@@ -55,6 +60,7 @@ public class CodexTests
         JObject turnRequest = transport.Messages.Single(message => message.Value<string>("method") == "turn/start");
         Assert.That(turnRequest["params"]?["input"]?.Count(), Is.EqualTo(1));
         Assert.That(turnRequest["params"]?["input"]?[0]?["type"]?.Value<string>(), Is.EqualTo("text"));
+        Assert.That(turnRequest["params"]?["serviceTier"]?.Value<string>(), Is.EqualTo("priority"));
         Assert.That(transport.Messages.Any(message => message.Value<string>("method")?.Contains("image") == true), Is.False);
     }
 
@@ -285,11 +291,23 @@ public class CodexTests
                 ["hidden"] = false,
                 ["isDefault"] = isDefault,
                 ["defaultReasoningEffort"] = efforts[0],
+                ["defaultServiceTier"] = "priority",
                 ["supportedReasoningEfforts"] = new JArray(efforts.Select(effort => new JObject
                 {
                     ["reasoningEffort"] = effort,
                     ["description"] = effort
                 })),
+                ["serviceTiers"] = new JArray(new JObject
+                {
+                    ["id"] = "priority",
+                    ["name"] = "Fast",
+                    ["description"] = "1.5x speed"
+                }, new JObject
+                {
+                    ["id"] = "future-tier",
+                    ["name"] = "Future",
+                    ["description"] = "Future catalog value"
+                }),
                 ["inputModalities"] = new JArray("text")
             };
         }

--- a/src/LlmTornado.Tests/CodexTests.cs
+++ b/src/LlmTornado.Tests/CodexTests.cs
@@ -1,0 +1,297 @@
+﻿using System.Collections.Concurrent;
+using LlmTornado.Codex;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Tests;
+
+[TestFixture]
+public class CodexTests
+{
+    [Test]
+    public async Task AppServer_AuthenticatesListsModelsAndRunsTextTurn()
+    {
+        FakeCodexTransport transport = new FakeCodexTransport();
+        await using CodexSession session = await CodexSession.ConnectAsync(new CodexAppServerOptions(), transport);
+
+        Assert.That(session.Initialization.CodexHome, Is.EqualTo("C:/codex"));
+
+        CodexAccountResult account = await session.GetAccountAsync(refreshToken: true);
+        Assert.That(account.Account?.PlanType, Is.EqualTo("pro"));
+        JObject accountRequest = transport.Messages.Single(message => message.Value<string>("method") == "account/read");
+        Assert.That(accountRequest["params"]?["refreshToken"]?.Value<bool>(), Is.True);
+
+        CodexBrowserLogin login = await session.StartBrowserLoginAsync();
+        Assert.That(login.AuthorizationUrl.Host, Is.EqualTo("chatgpt.com"));
+        CodexLoginResult loginResult = await login.WaitAsync();
+        Assert.That(loginResult.Success, Is.True);
+
+        IReadOnlyList<CodexModel> models = await session.ListModelsAsync();
+        Assert.That(models.Select(x => x.Model), Is.EqualTo(new[] { "gpt-5.4", "gpt-5.3-codex" }));
+        Assert.That(
+            models[0].SupportedReasoningEfforts.Select(x => x.ReasoningEffort),
+            Is.EqualTo(new[] { "low", "medium", "high" }));
+
+        CodexThread thread = await session.StartThreadAsync(new CodexThreadOptions
+        {
+            Model = models[1].Model,
+            WorkingDirectory = "D:/repo"
+        });
+        List<string> deltas = [];
+        CodexTurnResult turn = await thread.RunAsync("Reply briefly.", new CodexTurnOptions
+        {
+            ReasoningEffort = "high",
+            OnTextDelta = delta =>
+            {
+                deltas.Add(delta.Delta);
+                return Task.CompletedTask;
+            }
+        });
+
+        Assert.That(turn.FinalResponse, Is.EqualTo("Codex reply"));
+        Assert.That(turn.Status, Is.EqualTo("completed"));
+        Assert.That(deltas, Is.EqualTo(new[] { "Codex ", "reply" }));
+
+        JObject turnRequest = transport.Messages.Single(message => message.Value<string>("method") == "turn/start");
+        Assert.That(turnRequest["params"]?["input"]?.Count(), Is.EqualTo(1));
+        Assert.That(turnRequest["params"]?["input"]?[0]?["type"]?.Value<string>(), Is.EqualTo("text"));
+        Assert.That(transport.Messages.Any(message => message.Value<string>("method")?.Contains("image") == true), Is.False);
+    }
+
+    [Test]
+    public async Task AppServer_UsesRequiredInitializationSequence()
+    {
+        FakeCodexTransport transport = new FakeCodexTransport();
+        await using CodexSession session = await CodexSession.ConnectAsync(new CodexAppServerOptions
+        {
+            ClientName = "test-client",
+            ClientTitle = "Test Client",
+            ClientVersion = "1.2.3"
+        }, transport);
+
+        Assert.That(transport.Messages[0].Value<string>("method"), Is.EqualTo("initialize"));
+        Assert.That(transport.Messages[0]["params"]?["clientInfo"]?["name"]?.Value<string>(), Is.EqualTo("test-client"));
+        Assert.That(transport.Messages[1].Value<string>("method"), Is.EqualTo("initialized"));
+        Assert.That(transport.Messages[1]["id"], Is.Null);
+    }
+
+    [Test]
+    [Category("Integration")]
+    public async Task InstalledAppServer_ConnectsAndReturnsModels()
+    {
+        if (Environment.GetEnvironmentVariable("LLMTORNADO_CODEX_LIVE_TEST") != "1")
+        {
+            Assert.Ignore("Set LLMTORNADO_CODEX_LIVE_TEST=1 to use the installed Codex app-server.");
+        }
+
+        TornadoApi api = new TornadoApi();
+        await using CodexSession session = await api.Codex.ConnectAsync();
+        CodexAccountResult account = await session.GetAccountAsync();
+        IReadOnlyList<CodexModel> models = await session.ListModelsAsync();
+
+        Assert.That(session.Initialization.UserAgent, Is.Not.Empty);
+        Assert.That(account.Account?.Type, Is.EqualTo("chatgpt"));
+        Assert.That(models, Is.Not.Empty);
+    }
+
+    private sealed class FakeCodexTransport : ICodexAppServerTransport
+    {
+        private readonly ConcurrentQueue<string> output = new ConcurrentQueue<string>();
+        private readonly SemaphoreSlim outputSignal = new SemaphoreSlim(0);
+        private bool stopped;
+
+        internal List<JObject> Messages { get; } = [];
+
+        public IReadOnlyCollection<string> RecentStandardError => Array.Empty<string>();
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public async Task<string?> ReadLineAsync(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                if (output.TryDequeue(out string? line))
+                {
+                    return line;
+                }
+
+                if (stopped)
+                {
+                    return null;
+                }
+
+                await outputSignal.WaitAsync(cancellationToken);
+            }
+        }
+
+        public Task WriteLineAsync(string line, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            JObject message = JObject.Parse(line);
+            Messages.Add(message);
+            string? method = message.Value<string>("method");
+            JToken? id = message["id"];
+
+            if (id is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            switch (method)
+            {
+                case "initialize":
+                    Respond(id, new JObject
+                    {
+                        ["userAgent"] = "codex-test",
+                        ["codexHome"] = "C:/codex",
+                        ["platformFamily"] = "windows",
+                        ["platformOs"] = "windows"
+                    });
+                    break;
+                case "account/login/start":
+                    Respond(id, new JObject
+                    {
+                        ["type"] = "chatgpt",
+                        ["loginId"] = "login-1",
+                        ["authUrl"] = "https://chatgpt.com/auth/codex"
+                    });
+                    Notify("account/login/completed", new JObject
+                    {
+                        ["loginId"] = "login-1",
+                        ["success"] = true,
+                        ["error"] = null
+                    });
+                    break;
+                case "account/read":
+                    Respond(id, new JObject
+                    {
+                        ["account"] = new JObject
+                        {
+                            ["type"] = "chatgpt",
+                            ["email"] = "user@example.com",
+                            ["planType"] = "pro"
+                        },
+                        ["requiresOpenaiAuth"] = true
+                    });
+                    break;
+                case "model/list":
+                    Respond(id, new JObject
+                    {
+                        ["data"] = new JArray
+                        {
+                            Model("gpt-5.4", true, "low", "medium", "high"),
+                            Model("gpt-5.3-codex", false, "medium", "high")
+                        },
+                        ["nextCursor"] = null
+                    });
+                    break;
+                case "thread/start":
+                    Respond(id, new JObject
+                    {
+                        ["model"] = message["params"]?["model"] ?? "gpt-5.4",
+                        ["thread"] = new JObject { ["id"] = "thread-1" }
+                    });
+                    break;
+                case "turn/start":
+                    Respond(id, new JObject
+                    {
+                        ["turn"] = new JObject
+                        {
+                            ["id"] = "turn-1",
+                            ["status"] = "inProgress"
+                        }
+                    });
+                    Notify("item/agentMessage/delta", new JObject
+                    {
+                        ["threadId"] = "thread-1",
+                        ["turnId"] = "turn-1",
+                        ["itemId"] = "item-1",
+                        ["delta"] = "Codex "
+                    });
+                    Notify("item/agentMessage/delta", new JObject
+                    {
+                        ["threadId"] = "thread-1",
+                        ["turnId"] = "turn-1",
+                        ["itemId"] = "item-1",
+                        ["delta"] = "reply"
+                    });
+                    Notify("turn/completed", new JObject
+                    {
+                        ["threadId"] = "thread-1",
+                        ["turn"] = new JObject
+                        {
+                            ["id"] = "turn-1",
+                            ["status"] = "completed"
+                        }
+                    });
+                    break;
+                default:
+                    Respond(id, new JObject());
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            stopped = true;
+            outputSignal.Release();
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            stopped = true;
+            outputSignal.Dispose();
+        }
+
+        private void Respond(JToken id, JToken result)
+        {
+            Enqueue(new JObject
+            {
+                ["id"] = id.DeepClone(),
+                ["result"] = result
+            });
+        }
+
+        private void Notify(string method, JObject parameters)
+        {
+            Enqueue(new JObject
+            {
+                ["method"] = method,
+                ["params"] = parameters
+            });
+        }
+
+        private void Enqueue(JObject message)
+        {
+            output.Enqueue(message.ToString(Formatting.None));
+            outputSignal.Release();
+        }
+
+        private static JObject Model(string model, bool isDefault, params string[] efforts)
+        {
+            return new JObject
+            {
+                ["id"] = model,
+                ["model"] = model,
+                ["displayName"] = model,
+                ["description"] = $"{model} description",
+                ["hidden"] = false,
+                ["isDefault"] = isDefault,
+                ["defaultReasoningEffort"] = efforts[0],
+                ["supportedReasoningEfforts"] = new JArray(efforts.Select(effort => new JObject
+                {
+                    ["reasoningEffort"] = effort,
+                    ["description"] = effort
+                })),
+                ["inputModalities"] = new JArray("text")
+            };
+        }
+    }
+}

--- a/src/LlmTornado/Codex/CodexEndpoint.cs
+++ b/src/LlmTornado/Codex/CodexEndpoint.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// Connects to ChatGPT subscription authentication and Codex text turns through the official app-server or direct OAuth.
+/// </summary>
+public sealed class CodexEndpoint
+{
+    internal CodexEndpoint()
+    {
+    }
+
+    /// <summary>
+    /// Starts and initializes a Codex app-server session.
+    /// </summary>
+    public Task<CodexSession> ConnectAsync(
+        CodexAppServerOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => CodexSession.ConnectAsync(options ?? new CodexAppServerOptions(), cancellationToken);
+
+    /// <summary>
+    /// Creates a standalone Codex session that authenticates directly with OpenAI through browser OAuth.
+    /// This path does not require a local Codex installation.
+    /// </summary>
+    public Task<CodexOAuthSession> ConnectOAuthAsync(
+        CodexOAuthOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => CodexOAuthSession.ConnectAsync(options ?? new CodexOAuthOptions(), cancellationToken);
+}

--- a/src/LlmTornado/Codex/CodexModels.cs
+++ b/src/LlmTornado/Codex/CodexModels.cs
@@ -1,0 +1,494 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// Settings used to launch and identify the official Codex app-server.
+/// </summary>
+public sealed class CodexAppServerOptions
+{
+    /// <summary>
+    /// Path or command name of the Codex executable. Defaults to resolving <c>codex</c> from <c>PATH</c>.
+    /// </summary>
+    public string ExecutablePath { get; set; } = "codex";
+
+    /// <summary>
+    /// Optional working directory for the app-server process.
+    /// </summary>
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>
+    /// Optional environment variables added to the app-server process.
+    /// </summary>
+    public Dictionary<string, string> EnvironmentVariables { get; set; } = [];
+
+    /// <summary>
+    /// Optional Codex configuration overrides passed as repeated <c>--config key=value</c> arguments.
+    /// </summary>
+    public List<string> ConfigOverrides { get; set; } = [];
+
+    /// <summary>
+    /// Client identifier reported to Codex and OpenAI compliance logs.
+    /// </summary>
+    public string ClientName { get; set; } = "llmtornado";
+
+    /// <summary>
+    /// Human-readable client title reported during initialization.
+    /// </summary>
+    public string ClientTitle { get; set; } = "LLM Tornado";
+
+    /// <summary>
+    /// Client version reported during initialization. The assembly version is used when omitted.
+    /// </summary>
+    public string? ClientVersion { get; set; }
+
+    /// <summary>
+    /// Handles server-initiated requests such as Codex approval prompts. Unhandled requests are rejected.
+    /// </summary>
+    public CodexServerRequestHandler? ServerRequestHandler { get; set; }
+}
+
+/// <summary>
+/// Handles a request initiated by the Codex app-server.
+/// </summary>
+public delegate Task<JToken?> CodexServerRequestHandler(CodexServerRequest request, CancellationToken cancellationToken);
+
+/// <summary>
+/// A request initiated by the Codex app-server.
+/// </summary>
+public sealed class CodexServerRequest
+{
+    internal CodexServerRequest(JToken id, string method, JObject parameters)
+    {
+        Id = id;
+        Method = method;
+        Parameters = parameters;
+    }
+
+    /// <summary>
+    /// Request identifier supplied by the app-server.
+    /// </summary>
+    public JToken Id { get; }
+
+    /// <summary>
+    /// App-server method name.
+    /// </summary>
+    public string Method { get; }
+
+    /// <summary>
+    /// Method parameters.
+    /// </summary>
+    public JObject Parameters { get; }
+}
+
+/// <summary>
+/// An app-server notification.
+/// </summary>
+public sealed class CodexNotification
+{
+    internal CodexNotification(string method, JObject parameters)
+    {
+        Method = method;
+        Parameters = parameters;
+    }
+
+    /// <summary>
+    /// Notification method.
+    /// </summary>
+    public string Method { get; }
+
+    /// <summary>
+    /// Notification parameters.
+    /// </summary>
+    public JObject Parameters { get; }
+}
+
+/// <summary>
+/// Metadata returned by the app-server initialization handshake.
+/// </summary>
+public sealed class CodexInitialization
+{
+    /// <summary>
+    /// User agent used by the app-server for upstream requests.
+    /// </summary>
+    [JsonProperty("userAgent")]
+    public string? UserAgent { get; set; }
+
+    /// <summary>
+    /// Active Codex home directory.
+    /// </summary>
+    [JsonProperty("codexHome")]
+    public string? CodexHome { get; set; }
+
+    /// <summary>
+    /// Runtime platform family.
+    /// </summary>
+    [JsonProperty("platformFamily")]
+    public string? PlatformFamily { get; set; }
+
+    /// <summary>
+    /// Runtime operating system.
+    /// </summary>
+    [JsonProperty("platformOs")]
+    public string? PlatformOs { get; set; }
+}
+
+/// <summary>
+/// Current Codex account details.
+/// </summary>
+public sealed class CodexAccount
+{
+    /// <summary>
+    /// Authentication account type.
+    /// </summary>
+    [JsonProperty("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// ChatGPT account email when available.
+    /// </summary>
+    [JsonProperty("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// ChatGPT subscription plan when available.
+    /// </summary>
+    [JsonProperty("planType")]
+    public string? PlanType { get; set; }
+}
+
+/// <summary>
+/// Result of reading the current Codex account.
+/// </summary>
+public sealed class CodexAccountResult
+{
+    /// <summary>
+    /// Current account, or null when signed out.
+    /// </summary>
+    [JsonProperty("account")]
+    public CodexAccount? Account { get; set; }
+
+    /// <summary>
+    /// Whether the selected model provider requires OpenAI authentication.
+    /// </summary>
+    [JsonProperty("requiresOpenaiAuth")]
+    public bool RequiresOpenAiAuthentication { get; set; }
+}
+
+/// <summary>
+/// Result of a ChatGPT login attempt.
+/// </summary>
+public sealed class CodexLoginResult
+{
+    /// <summary>
+    /// Login attempt identifier.
+    /// </summary>
+    [JsonProperty("loginId")]
+    public string? LoginId { get; set; }
+
+    /// <summary>
+    /// Whether authentication completed successfully.
+    /// </summary>
+    [JsonProperty("success")]
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Authentication error reported by the app-server.
+    /// </summary>
+    [JsonProperty("error")]
+    public string? Error { get; set; }
+}
+
+/// <summary>
+/// Browser-based ChatGPT login managed by the Codex app-server.
+/// </summary>
+public sealed class CodexBrowserLogin
+{
+    private readonly CodexSession session;
+
+    internal CodexBrowserLogin(CodexSession session, string loginId, Uri authorizationUrl)
+    {
+        this.session = session;
+        LoginId = loginId;
+        AuthorizationUrl = authorizationUrl;
+    }
+
+    /// <summary>
+    /// Identifier of this login attempt.
+    /// </summary>
+    public string LoginId { get; }
+
+    /// <summary>
+    /// URL the host application should open in a browser.
+    /// </summary>
+    public Uri AuthorizationUrl { get; }
+
+    /// <summary>
+    /// Waits for the app-server to report completion of the browser login.
+    /// </summary>
+    public Task<CodexLoginResult> WaitAsync(CancellationToken cancellationToken = default)
+        => session.WaitForLoginAsync(LoginId, cancellationToken);
+
+    /// <summary>
+    /// Cancels this login attempt.
+    /// </summary>
+    public Task CancelAsync(CancellationToken cancellationToken = default)
+        => session.CancelLoginAsync(LoginId, cancellationToken);
+}
+
+/// <summary>
+/// A reasoning effort advertised for a Codex model.
+/// </summary>
+public sealed class CodexReasoningEffort
+{
+    /// <summary>
+    /// Reasoning effort identifier sent to the app-server.
+    /// </summary>
+    [JsonProperty("reasoningEffort")]
+    public string ReasoningEffort { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable effort description.
+    /// </summary>
+    [JsonProperty("description")]
+    public string Description { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A model advertised by the authenticated Codex app-server.
+/// </summary>
+public sealed class CodexModel
+{
+    /// <summary>
+    /// Catalog entry identifier.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Model identifier used for thread and turn requests.
+    /// </summary>
+    [JsonProperty("model")]
+    public string Model { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable model name.
+    /// </summary>
+    [JsonProperty("displayName")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Model description supplied by Codex.
+    /// </summary>
+    [JsonProperty("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Model-specific base instructions required by the direct Codex backend.
+    /// </summary>
+    [JsonProperty("baseInstructions")]
+    public string BaseInstructions { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether this entry is hidden from the default model picker.
+    /// </summary>
+    [JsonProperty("hidden")]
+    public bool Hidden { get; set; }
+
+    /// <summary>
+    /// Whether this is the catalog's default model.
+    /// </summary>
+    [JsonProperty("isDefault")]
+    public bool IsDefault { get; set; }
+
+    /// <summary>
+    /// Default reasoning effort for this model.
+    /// </summary>
+    [JsonProperty("defaultReasoningEffort")]
+    public string DefaultReasoningEffort { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Supported reasoning efforts in the server-defined display order.
+    /// </summary>
+    [JsonProperty("supportedReasoningEfforts")]
+    public List<CodexReasoningEffort> SupportedReasoningEfforts { get; set; } = [];
+
+    /// <summary>
+    /// Input modalities advertised by the model.
+    /// </summary>
+    [JsonProperty("inputModalities")]
+    public List<string> InputModalities { get; set; } = [];
+
+    /// <summary>
+    /// Whether the model supports Codex personality settings.
+    /// </summary>
+    [JsonProperty("supportsPersonality")]
+    public bool SupportsPersonality { get; set; }
+}
+
+internal sealed class CodexModelPage
+{
+    [JsonProperty("data")]
+    public List<CodexModel> Data { get; set; } = [];
+
+    [JsonProperty("nextCursor")]
+    public string? NextCursor { get; set; }
+}
+
+/// <summary>
+/// Options for a new Codex thread.
+/// </summary>
+public sealed class CodexThreadOptions
+{
+    /// <summary>
+    /// Model identifier from <see cref="CodexSession.ListModelsAsync"/>.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Working directory available to the Codex thread.
+    /// </summary>
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>
+    /// Codex approval policy, such as <c>never</c> or <c>on-request</c>.
+    /// </summary>
+    public string? ApprovalPolicy { get; set; }
+
+    /// <summary>
+    /// Codex sandbox mode, such as <c>readOnly</c> or <c>workspaceWrite</c>.
+    /// </summary>
+    public string? Sandbox { get; set; }
+
+    /// <summary>
+    /// If true, keeps the thread in memory without persisting it.
+    /// </summary>
+    public bool? Ephemeral { get; set; }
+}
+
+/// <summary>
+/// Per-turn text generation options.
+/// </summary>
+public sealed class CodexTurnOptions
+{
+    /// <summary>
+    /// Optional model override from <see cref="CodexSession.ListModelsAsync"/>.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Optional reasoning effort advertised by the selected model.
+    /// </summary>
+    public string? ReasoningEffort { get; set; }
+
+    /// <summary>
+    /// Receives streamed assistant text deltas.
+    /// </summary>
+    public Func<CodexTextDelta, Task>? OnTextDelta { get; set; }
+}
+
+/// <summary>
+/// A streamed assistant text delta.
+/// </summary>
+public sealed class CodexTextDelta
+{
+    internal CodexTextDelta(string threadId, string turnId, string itemId, string delta)
+    {
+        ThreadId = threadId;
+        TurnId = turnId;
+        ItemId = itemId;
+        Delta = delta;
+    }
+
+    /// <summary>
+    /// Thread that produced the delta.
+    /// </summary>
+    public string ThreadId { get; }
+
+    /// <summary>
+    /// Turn that produced the delta.
+    /// </summary>
+    public string TurnId { get; }
+
+    /// <summary>
+    /// Agent-message item that produced the delta.
+    /// </summary>
+    public string ItemId { get; }
+
+    /// <summary>
+    /// Text appended by this event.
+    /// </summary>
+    public string Delta { get; }
+}
+
+/// <summary>
+/// Final result of a Codex text turn.
+/// </summary>
+public sealed class CodexTurnResult
+{
+    internal CodexTurnResult(string threadId, string turnId, string finalResponse, string? status, JObject turn)
+    {
+        ThreadId = threadId;
+        TurnId = turnId;
+        FinalResponse = finalResponse;
+        Status = status;
+        Turn = turn;
+    }
+
+    /// <summary>
+    /// Thread that produced the result.
+    /// </summary>
+    public string ThreadId { get; }
+
+    /// <summary>
+    /// Completed turn identifier.
+    /// </summary>
+    public string TurnId { get; }
+
+    /// <summary>
+    /// Concatenated assistant text.
+    /// </summary>
+    public string FinalResponse { get; }
+
+    /// <summary>
+    /// Final app-server turn status.
+    /// </summary>
+    public string? Status { get; }
+
+    /// <summary>
+    /// Raw completed turn object for protocol fields not projected by this wrapper.
+    /// </summary>
+    public JObject Turn { get; }
+}
+
+/// <summary>
+/// Error returned by the Codex app-server.
+/// </summary>
+public sealed class CodexRpcException : Exception
+{
+    internal CodexRpcException(int code, string message, JToken? data = null) : base(message)
+    {
+        Code = code;
+        DataToken = data;
+    }
+
+    /// <summary>
+    /// JSON-RPC error code.
+    /// </summary>
+    public int Code { get; }
+
+    /// <summary>
+    /// Optional app-server error data.
+    /// </summary>
+    public JToken? DataToken { get; }
+
+    /// <summary>
+    /// Whether the app-server reported transient overload.
+    /// </summary>
+    public bool IsRetryable => Code == -32001;
+}

--- a/src/LlmTornado/Codex/CodexModels.cs
+++ b/src/LlmTornado/Codex/CodexModels.cs
@@ -260,6 +260,30 @@ public sealed class CodexReasoningEffort
 }
 
 /// <summary>
+/// A service tier advertised for a Codex model.
+/// </summary>
+public sealed class CodexServiceTier
+{
+    /// <summary>
+    /// Service-tier identifier sent with a turn request.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable service-tier name.
+    /// </summary>
+    [JsonProperty("name")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable service-tier description.
+    /// </summary>
+    [JsonProperty("description")]
+    public string Description { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// A model advertised by the authenticated Codex app-server.
 /// </summary>
 public sealed class CodexModel
@@ -317,6 +341,18 @@ public sealed class CodexModel
     /// </summary>
     [JsonProperty("supportedReasoningEfforts")]
     public List<CodexReasoningEffort> SupportedReasoningEfforts { get; set; } = [];
+
+    /// <summary>
+    /// Service tiers supported by this model.
+    /// </summary>
+    [JsonProperty("serviceTiers")]
+    public List<CodexServiceTier> ServiceTiers { get; set; } = [];
+
+    /// <summary>
+    /// Catalog default service-tier identifier for this model.
+    /// </summary>
+    [JsonProperty("defaultServiceTier")]
+    public string DefaultServiceTier { get; set; } = string.Empty;
 
     /// <summary>
     /// Input modalities advertised by the model.
@@ -385,6 +421,11 @@ public sealed class CodexTurnOptions
     /// Optional reasoning effort advertised by the selected model.
     /// </summary>
     public string? ReasoningEffort { get; set; }
+
+    /// <summary>
+    /// Optional service tier advertised by the selected model.
+    /// </summary>
+    public string? ServiceTier { get; set; }
 
     /// <summary>
     /// Receives streamed assistant text deltas.

--- a/src/LlmTornado/Codex/CodexOAuthModels.cs
+++ b/src/LlmTornado/Codex/CodexOAuthModels.cs
@@ -1,0 +1,502 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// Settings for direct ChatGPT subscription authentication and Codex requests.
+/// </summary>
+public sealed class CodexOAuthOptions
+{
+    /// <summary>
+    /// OpenAI OAuth issuer.
+    /// </summary>
+    public Uri Issuer { get; set; } = new Uri("https://auth.openai.com");
+
+    /// <summary>
+    /// ChatGPT Codex backend base URI.
+    /// </summary>
+    public Uri ApiBaseUri { get; set; } = new Uri("https://chatgpt.com/backend-api/codex/");
+
+    /// <summary>
+    /// Public OAuth client identifier used by the official Codex applications.
+    /// </summary>
+    public string ClientId { get; set; } = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+    /// <summary>
+    /// Preferred localhost callback port. The official Codex redirect allow-list uses 1455.
+    /// Set to zero only for controlled test environments.
+    /// </summary>
+    public int CallbackPort { get; set; } = 1455;
+
+    /// <summary>
+    /// Fallback localhost callback port. The official Codex redirect allow-list uses 1457.
+    /// </summary>
+    public int FallbackCallbackPort { get; set; } = 1457;
+
+    /// <summary>
+    /// Client identifier sent in Codex request headers and the OAuth authorization request.
+    /// </summary>
+    public string Originator { get; set; } = "llmtornado";
+
+    /// <summary>
+    /// Client version sent to the model catalog and Codex backend.
+    /// </summary>
+    public string? ClientVersion { get; set; }
+
+    /// <summary>
+    /// How early an access token is refreshed before its expiry.
+    /// </summary>
+    public TimeSpan RefreshBeforeExpiration { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Persistent credential store. Defaults to a file in the current user's local application data.
+    /// </summary>
+    public ICodexOAuthCredentialStore CredentialStore { get; set; } = new CodexOAuthFileCredentialStore();
+
+    /// <summary>
+    /// Optional HTTP client used for OAuth and Codex backend requests. The caller retains ownership.
+    /// </summary>
+    public HttpClient? HttpClient { get; set; }
+}
+
+/// <summary>
+/// Persists direct Codex OAuth credentials, including rotating refresh tokens.
+/// </summary>
+public interface ICodexOAuthCredentialStore
+{
+    /// <summary>
+    /// Loads the current credentials, or null when signed out.
+    /// </summary>
+    Task<CodexOAuthCredentials?> LoadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces the stored credentials after login or token refresh.
+    /// </summary>
+    Task SaveAsync(CodexOAuthCredentials credentials, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes stored credentials.
+    /// </summary>
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// File-backed direct Codex OAuth credential store.
+/// </summary>
+public sealed class CodexOAuthFileCredentialStore : ICodexOAuthCredentialStore
+{
+    private readonly SemaphoreSlim fileLock = new SemaphoreSlim(1, 1);
+
+    /// <summary>
+    /// Creates a credential store at the supplied path or the default per-user path.
+    /// </summary>
+    public CodexOAuthFileCredentialStore(string? filePath = null)
+    {
+        FilePath = filePath ?? GetDefaultPath();
+    }
+
+    /// <summary>
+    /// File containing the OAuth credentials. Treat this file as a secret.
+    /// </summary>
+    public string FilePath { get; }
+
+    /// <inheritdoc />
+    public async Task<CodexOAuthCredentials?> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        await fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(FilePath))
+            {
+                return null;
+            }
+
+            string json = File.ReadAllText(FilePath);
+            return JsonConvert.DeserializeObject<CodexOAuthCredentials>(json);
+        }
+        finally
+        {
+            fileLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(CodexOAuthCredentials credentials, CancellationToken cancellationToken = default)
+    {
+        if (credentials is null)
+        {
+            throw new ArgumentNullException(nameof(credentials));
+        }
+
+        await fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            string? directory = Path.GetDirectoryName(FilePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(FilePath, JsonConvert.SerializeObject(credentials, Formatting.Indented));
+        }
+        finally
+        {
+            fileLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        await fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (File.Exists(FilePath))
+            {
+                File.Delete(FilePath);
+            }
+        }
+        finally
+        {
+            fileLock.Release();
+        }
+    }
+
+    private static string GetDefaultPath()
+    {
+        string root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(root, "LlmTornado", "codex-oauth.json");
+    }
+}
+
+/// <summary>
+/// In-memory credential store for applications that provide their own persistence lifecycle.
+/// </summary>
+public sealed class CodexOAuthMemoryCredentialStore : ICodexOAuthCredentialStore
+{
+    private CodexOAuthCredentials? credentials;
+
+    /// <summary>
+    /// Creates an empty store or seeds it with existing credentials.
+    /// </summary>
+    public CodexOAuthMemoryCredentialStore(CodexOAuthCredentials? credentials = null)
+    {
+        this.credentials = credentials?.Clone();
+    }
+
+    /// <inheritdoc />
+    public Task<CodexOAuthCredentials?> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(credentials?.Clone());
+    }
+
+    /// <inheritdoc />
+    public Task SaveAsync(CodexOAuthCredentials credentials, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        this.credentials = credentials.Clone();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        credentials = null;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Direct ChatGPT OAuth credentials. Access and refresh token values are secrets.
+/// </summary>
+public sealed class CodexOAuthCredentials
+{
+    /// <summary>
+    /// OpenID identity token.
+    /// </summary>
+    [JsonProperty("id_token")]
+    public string IdToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Bearer token used with the ChatGPT Codex backend.
+    /// </summary>
+    [JsonProperty("access_token")]
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Rotating OAuth refresh token.
+    /// </summary>
+    [JsonProperty("refresh_token")]
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// ChatGPT workspace/account identifier.
+    /// </summary>
+    [JsonProperty("account_id")]
+    public string? AccountId { get; set; }
+
+    /// <summary>
+    /// Account email extracted from token claims.
+    /// </summary>
+    [JsonProperty("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// ChatGPT subscription plan extracted from token claims.
+    /// </summary>
+    [JsonProperty("plan_type")]
+    public string? PlanType { get; set; }
+
+    /// <summary>
+    /// Whether the account requires FedRAMP routing.
+    /// </summary>
+    [JsonProperty("is_fedramp")]
+    public bool IsFedRamp { get; set; }
+
+    /// <summary>
+    /// Access-token expiration when present in the JWT.
+    /// </summary>
+    [JsonProperty("expires_at_utc")]
+    public DateTimeOffset? ExpiresAtUtc { get; set; }
+
+    /// <summary>
+    /// Time at which these credentials were issued or refreshed.
+    /// </summary>
+    [JsonProperty("last_refresh_utc")]
+    public DateTimeOffset LastRefreshUtc { get; set; }
+
+    internal CodexOAuthCredentials Clone()
+        => (CodexOAuthCredentials)MemberwiseClone();
+}
+
+/// <summary>
+/// Result of a direct browser OAuth login.
+/// </summary>
+public sealed class CodexOAuthLoginResult
+{
+    internal CodexOAuthLoginResult(bool success, CodexAccount? account, string? error)
+    {
+        Success = success;
+        Account = account;
+        Error = error;
+    }
+
+    /// <summary>
+    /// Whether login and credential persistence completed successfully.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// Authenticated ChatGPT account.
+    /// </summary>
+    public CodexAccount? Account { get; }
+
+    /// <summary>
+    /// Error reported by the callback or token exchange.
+    /// </summary>
+    public string? Error { get; }
+}
+
+/// <summary>
+/// A running direct browser OAuth login.
+/// </summary>
+public sealed class CodexOAuthBrowserLogin
+{
+    private readonly CodexOAuthLoginOperation operation;
+
+    internal CodexOAuthBrowserLogin(CodexOAuthLoginOperation operation)
+    {
+        this.operation = operation;
+    }
+
+    /// <summary>
+    /// URL the host application should open in the user's browser.
+    /// </summary>
+    public Uri AuthorizationUrl => operation.AuthorizationUrl;
+
+    /// <summary>
+    /// Local callback port selected for this login.
+    /// </summary>
+    public int CallbackPort => operation.CallbackPort;
+
+    /// <summary>
+    /// Waits for the browser callback and token exchange.
+    /// </summary>
+    public Task<CodexOAuthLoginResult> WaitAsync(CancellationToken cancellationToken = default)
+        => operation.WaitAsync(cancellationToken);
+
+    /// <summary>
+    /// Cancels the local callback listener.
+    /// </summary>
+    public Task CancelAsync()
+        => operation.CancelAsync();
+}
+
+/// <summary>
+/// Options for a direct OAuth-backed Codex text thread.
+/// </summary>
+public sealed class CodexOAuthThreadOptions
+{
+    /// <summary>
+    /// Model identifier returned by <see cref="CodexOAuthSession.ListModelsAsync"/>.
+    /// The default catalog model is selected when omitted.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Optional developer instructions added to the client-managed thread history.
+    /// </summary>
+    public string? Instructions { get; set; }
+}
+
+/// <summary>
+/// Options for one direct OAuth-backed Codex text turn.
+/// </summary>
+public sealed class CodexOAuthTurnOptions
+{
+    /// <summary>
+    /// Optional reasoning effort advertised by the selected model.
+    /// </summary>
+    public string? ReasoningEffort { get; set; }
+
+    /// <summary>
+    /// Receives streamed assistant text deltas.
+    /// </summary>
+    public Func<CodexOAuthTextDelta, Task>? OnTextDelta { get; set; }
+}
+
+/// <summary>
+/// A streamed assistant text delta from the direct Codex backend.
+/// </summary>
+public sealed class CodexOAuthTextDelta
+{
+    internal CodexOAuthTextDelta(string threadId, string responseId, string itemId, string delta)
+    {
+        ThreadId = threadId;
+        ResponseId = responseId;
+        ItemId = itemId;
+        Delta = delta;
+    }
+
+    /// <summary>
+    /// Client-side thread identifier.
+    /// </summary>
+    public string ThreadId { get; }
+
+    /// <summary>
+    /// Backend response identifier when available.
+    /// </summary>
+    public string ResponseId { get; }
+
+    /// <summary>
+    /// Output item identifier when available.
+    /// </summary>
+    public string ItemId { get; }
+
+    /// <summary>
+    /// Text appended by this event.
+    /// </summary>
+    public string Delta { get; }
+}
+
+/// <summary>
+/// Final result of a direct OAuth-backed Codex text turn.
+/// </summary>
+public sealed class CodexOAuthTurnResult
+{
+    internal CodexOAuthTurnResult(
+        string threadId,
+        string responseId,
+        string finalResponse,
+        string? status,
+        JObject response,
+        IReadOnlyList<JObject> outputItems)
+    {
+        ThreadId = threadId;
+        ResponseId = responseId;
+        FinalResponse = finalResponse;
+        Status = status;
+        Response = response;
+        OutputItems = outputItems;
+    }
+
+    /// <summary>
+    /// Client-side thread identifier.
+    /// </summary>
+    public string ThreadId { get; }
+
+    /// <summary>
+    /// Backend response identifier.
+    /// </summary>
+    public string ResponseId { get; }
+
+    /// <summary>
+    /// Concatenated assistant text.
+    /// </summary>
+    public string FinalResponse { get; }
+
+    /// <summary>
+    /// Final response status.
+    /// </summary>
+    public string? Status { get; }
+
+    /// <summary>
+    /// Raw completed response object.
+    /// </summary>
+    public JObject Response { get; }
+
+    internal IReadOnlyList<JObject> OutputItems { get; }
+}
+
+/// <summary>
+/// Error returned by direct OAuth or ChatGPT Codex backend operations.
+/// </summary>
+public sealed class CodexOAuthException : Exception
+{
+    internal CodexOAuthException(string message, int? statusCode = null, string? responseBody = null, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        StatusCode = statusCode;
+        ResponseBody = responseBody;
+    }
+
+    /// <summary>
+    /// HTTP status code when the error originated from an HTTP response.
+    /// </summary>
+    public int? StatusCode { get; }
+
+    /// <summary>
+    /// Response body when available.
+    /// </summary>
+    public string? ResponseBody { get; }
+}
+
+internal sealed class CodexOAuthTokenResponse
+{
+    [JsonProperty("id_token")]
+    public string? IdToken { get; set; }
+
+    [JsonProperty("access_token")]
+    public string? AccessToken { get; set; }
+
+    [JsonProperty("refresh_token")]
+    public string? RefreshToken { get; set; }
+
+    [JsonProperty("expires_in")]
+    public long? ExpiresIn { get; set; }
+}
+
+internal sealed class CodexBackendModelsResponse
+{
+    [JsonProperty("models")]
+    public List<JObject> Models { get; set; } = [];
+}

--- a/src/LlmTornado/Codex/CodexOAuthModels.cs
+++ b/src/LlmTornado/Codex/CodexOAuthModels.cs
@@ -15,6 +15,11 @@ namespace LlmTornado.Codex;
 public sealed class CodexOAuthOptions
 {
     /// <summary>
+    /// Codex protocol version used when the caller does not provide an override.
+    /// </summary>
+    public const string DefaultCodexProtocolVersion = "0.146.0";
+
+    /// <summary>
     /// OpenAI OAuth issuer.
     /// </summary>
     public Uri Issuer { get; set; } = new Uri("https://auth.openai.com");
@@ -46,9 +51,15 @@ public sealed class CodexOAuthOptions
     public string Originator { get; set; } = "llmtornado";
 
     /// <summary>
-    /// Client version sent to the model catalog and Codex backend.
+    /// Client version sent in Codex backend headers and the user agent.
     /// </summary>
     public string? ClientVersion { get; set; }
+
+    /// <summary>
+    /// Codex protocol version sent as <c>client_version</c> to the subscription model catalog.
+    /// This is independent of the LLMTornado package version.
+    /// </summary>
+    public string CodexProtocolVersion { get; set; } = DefaultCodexProtocolVersion;
 
     /// <summary>
     /// How early an access token is refreshed before its expiry.
@@ -367,6 +378,11 @@ public sealed class CodexOAuthTurnOptions
     /// Optional reasoning effort advertised by the selected model.
     /// </summary>
     public string? ReasoningEffort { get; set; }
+
+    /// <summary>
+    /// Optional service tier advertised by the selected model.
+    /// </summary>
+    public string? ServiceTier { get; set; }
 
     /// <summary>
     /// Receives streamed assistant text deltas.

--- a/src/LlmTornado/Codex/CodexOAuthSession.cs
+++ b/src/LlmTornado/Codex/CodexOAuthSession.cs
@@ -1,0 +1,725 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// Direct ChatGPT subscription session with browser OAuth, token refresh, model discovery, and text turns.
+/// </summary>
+public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
+{
+    private static readonly TimeSpan FallbackRefreshInterval = TimeSpan.FromDays(8);
+    private readonly CodexOAuthOptions options;
+    private readonly ICodexOAuthCredentialStore credentialStore;
+    private readonly HttpClient httpClient;
+    private readonly bool ownsHttpClient;
+    private readonly SemaphoreSlim credentialLock = new SemaphoreSlim(1, 1);
+    private CodexOAuthCredentials? credentials;
+    private bool disposed;
+
+    private CodexOAuthSession(
+        CodexOAuthOptions options,
+        HttpClient httpClient,
+        bool ownsHttpClient,
+        CodexOAuthCredentials? credentials)
+    {
+        this.options = options;
+        this.httpClient = httpClient;
+        this.ownsHttpClient = ownsHttpClient;
+        this.credentials = credentials;
+        credentialStore = options.CredentialStore;
+        ClientVersion = options.ClientVersion
+                        ?? typeof(CodexOAuthSession).Assembly.GetName().Version?.ToString()
+                        ?? "0.0.0";
+    }
+
+    /// <summary>
+    /// Client version sent to the Codex backend.
+    /// </summary>
+    public string ClientVersion { get; }
+
+    internal static async Task<CodexOAuthSession> ConnectAsync(
+        CodexOAuthOptions options,
+        CancellationToken cancellationToken)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (options.CredentialStore is null)
+        {
+            throw new ArgumentNullException(nameof(options.CredentialStore));
+        }
+
+        CodexOAuthCredentials? credentials =
+            await options.CredentialStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+        bool ownsHttpClient = options.HttpClient is null;
+        HttpClient client = options.HttpClient ?? new HttpClient();
+        return new CodexOAuthSession(options, client, ownsHttpClient, credentials);
+    }
+
+    /// <summary>
+    /// Reads the current account. Set <paramref name="refreshToken"/> to force a token refresh first.
+    /// </summary>
+    public async Task<CodexAccountResult> GetAccountAsync(
+        bool refreshToken = false,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        CodexOAuthCredentials? current = credentials;
+        if (current is null)
+        {
+            return new CodexAccountResult
+            {
+                Account = null,
+                RequiresOpenAiAuthentication = true
+            };
+        }
+
+        current = await GetValidCredentialsAsync(refreshToken, cancellationToken).ConfigureAwait(false);
+        return new CodexAccountResult
+        {
+            Account = ToAccount(current),
+            RequiresOpenAiAuthentication = true
+        };
+    }
+
+    /// <summary>
+    /// Starts a direct browser OAuth login and local callback listener.
+    /// </summary>
+    public Task<CodexOAuthBrowserLogin> StartBrowserLoginAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new CodexOAuthBrowserLogin(CodexOAuthLoginOperation.Start(this, options)));
+    }
+
+    /// <summary>
+    /// Revokes the current refresh token on a best-effort basis and clears the credential store.
+    /// </summary>
+    public async Task LogoutAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        await credentialLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            CodexOAuthCredentials? current = credentials;
+            credentials = null;
+
+            if (current is not null)
+            {
+                await TryRevokeAsync(current, cancellationToken).ConfigureAwait(false);
+            }
+
+            await credentialStore.ClearAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            credentialLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Lists text-capable Codex models available to the authenticated ChatGPT subscription.
+    /// </summary>
+    public async Task<IReadOnlyList<CodexModel>> ListModelsAsync(
+        bool includeHidden = false,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        Uri modelsUri = CodexOAuthProtocol.GetApiEndpoint(
+            options,
+            $"models?client_version={Uri.EscapeDataString(ClientVersion)}");
+
+        using HttpResponseMessage response = await SendAuthenticatedAsync(
+            () => new HttpRequestMessage(HttpMethod.Get, modelsUri),
+            HttpCompletionOption.ResponseContentRead,
+            cancellationToken).ConfigureAwait(false);
+        string body = await ReadContentAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body, "Codex model discovery failed.");
+
+        CodexBackendModelsResponse catalog =
+            JsonConvert.DeserializeObject<CodexBackendModelsResponse>(body)
+            ?? new CodexBackendModelsResponse();
+        List<CodexModel> models = [];
+
+        foreach (JObject source in catalog.Models)
+        {
+            bool supportedInApi = source.Value<bool?>("supported_in_api") ?? true;
+            string visibility = source.Value<string>("visibility") ?? "list";
+            bool showInPicker = source.Value<bool?>("show_in_picker") ?? true;
+            bool hidden = !string.Equals(visibility, "list", StringComparison.OrdinalIgnoreCase) || !showInPicker;
+
+            if (!supportedInApi || (!includeHidden && hidden))
+            {
+                continue;
+            }
+
+            string modelId = source.Value<string>("slug")
+                             ?? source.Value<string>("id")
+                             ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(modelId))
+            {
+                continue;
+            }
+
+            CodexModel model = new CodexModel
+            {
+                Id = modelId,
+                Model = modelId,
+                DisplayName = source.Value<string>("display_name") ?? modelId,
+                Description = source.Value<string>("description") ?? string.Empty,
+                BaseInstructions = source.Value<string>("base_instructions") ?? string.Empty,
+                Hidden = hidden,
+                IsDefault = source.Value<bool?>("is_default") ?? false,
+                DefaultReasoningEffort = source.Value<string>("default_reasoning_level") ?? string.Empty,
+                SupportsPersonality = source.Value<bool?>("supports_personality") ?? false,
+                InputModalities = source["input_modalities"]?.Values<string>().ToList() ?? []
+            };
+
+            if (source["supported_reasoning_levels"] is JArray efforts)
+            {
+                foreach (JObject effort in efforts.OfType<JObject>())
+                {
+                    model.SupportedReasoningEfforts.Add(new CodexReasoningEffort
+                    {
+                        ReasoningEffort = effort.Value<string>("effort") ?? string.Empty,
+                        Description = effort.Value<string>("description") ?? string.Empty
+                    });
+                }
+            }
+
+            models.Add(model);
+        }
+
+        return models;
+    }
+
+    /// <summary>
+    /// Creates a client-side text thread using a subscription model.
+    /// </summary>
+    public async Task<CodexOAuthThread> StartThreadAsync(
+        CodexOAuthThreadOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        options ??= new CodexOAuthThreadOptions();
+        bool hasExplicitModel = !string.IsNullOrWhiteSpace(options.Model);
+        IReadOnlyList<CodexModel> models = await ListModelsAsync(
+            includeHidden: hasExplicitModel,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        CodexModel? selectedModel = hasExplicitModel
+            ? models.FirstOrDefault(candidate =>
+                string.Equals(candidate.Model, options.Model, StringComparison.Ordinal))
+            : models.FirstOrDefault(candidate => candidate.IsDefault) ?? models.FirstOrDefault();
+
+        if (selectedModel is null)
+        {
+            throw new CodexOAuthException(
+                hasExplicitModel
+                    ? $"The ChatGPT subscription does not provide Codex model '{options.Model}'."
+                    : "The ChatGPT subscription did not return a usable Codex model.");
+        }
+
+        if (string.IsNullOrWhiteSpace(selectedModel.BaseInstructions))
+        {
+            throw new CodexOAuthException(
+                $"The Codex model catalog did not provide base instructions for '{selectedModel.Model}'.");
+        }
+
+        return new CodexOAuthThread(
+            this,
+            Guid.NewGuid().ToString(),
+            selectedModel.Model,
+            selectedModel.BaseInstructions,
+            options.Instructions);
+    }
+
+    internal async Task<CodexAccount> CompleteBrowserLoginAsync(
+        string code,
+        Uri redirectUri,
+        string codeVerifier,
+        CancellationToken cancellationToken)
+    {
+        using FormUrlEncodedContent content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = redirectUri.AbsoluteUri,
+            ["client_id"] = options.ClientId,
+            ["code_verifier"] = codeVerifier
+        });
+        using HttpRequestMessage request = new HttpRequestMessage(
+            HttpMethod.Post,
+            CodexOAuthProtocol.GetIssuerEndpoint(options, "oauth/token"))
+        {
+            Content = content
+        };
+        ApplyClientHeaders(request);
+
+        using HttpResponseMessage response =
+            await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        string body = await ReadContentAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body, "OAuth authorization-code exchange failed.");
+        CodexOAuthTokenResponse tokenResponse =
+            JsonConvert.DeserializeObject<CodexOAuthTokenResponse>(body)
+            ?? throw new CodexOAuthException("OpenAI returned an empty OAuth token response.");
+
+        await credentialLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            CodexOAuthCredentials updated = CodexOAuthProtocol.MergeCredentials(tokenResponse, credentials);
+            await credentialStore.SaveAsync(updated, cancellationToken).ConfigureAwait(false);
+            credentials = updated;
+            return ToAccount(updated);
+        }
+        finally
+        {
+            credentialLock.Release();
+        }
+    }
+
+    internal async Task<CodexOAuthTurnResult> RunTextTurnAsync(
+        string threadId,
+        string model,
+        string baseInstructions,
+        IReadOnlyList<JObject> input,
+        CodexOAuthTurnOptions turnOptions,
+        CancellationToken cancellationToken)
+    {
+        JObject payload = new JObject
+        {
+            ["model"] = model,
+            ["instructions"] = baseInstructions,
+            ["input"] = new JArray(input.Select(item => item.DeepClone())),
+            ["tools"] = new JArray(),
+            ["tool_choice"] = "auto",
+            ["parallel_tool_calls"] = false,
+            ["store"] = false,
+            ["stream"] = true,
+            ["include"] = new JArray("reasoning.encrypted_content")
+        };
+
+        if (!string.IsNullOrWhiteSpace(turnOptions.ReasoningEffort))
+        {
+            payload["reasoning"] = new JObject
+            {
+                ["effort"] = turnOptions.ReasoningEffort,
+                ["summary"] = "auto"
+            };
+        }
+
+        Uri responsesUri = CodexOAuthProtocol.GetApiEndpoint(options, "responses");
+        using HttpResponseMessage response = await SendAuthenticatedAsync(
+            () =>
+            {
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, responsesUri)
+                {
+                    Content = new StringContent(
+                        payload.ToString(Formatting.None),
+                        Encoding.UTF8,
+                        "application/json")
+                };
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+                request.Headers.TryAddWithoutValidation("session-id", threadId);
+                request.Headers.TryAddWithoutValidation("thread-id", threadId);
+                request.Headers.TryAddWithoutValidation("x-client-request-id", threadId);
+                return request;
+            },
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            string errorBody = await ReadContentAsync(response.Content, cancellationToken).ConfigureAwait(false);
+            EnsureSuccess(response, errorBody, "Codex text turn failed.");
+        }
+
+        return await ParseResponseStreamAsync(
+            response,
+            threadId,
+            turnOptions.OnTextDelta,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CodexOAuthCredentials> GetValidCredentialsAsync(
+        bool forceRefresh,
+        CancellationToken cancellationToken)
+    {
+        await credentialLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            CodexOAuthCredentials current = credentials
+                ?? throw new CodexOAuthException("ChatGPT authentication is required. Start browser OAuth login first.");
+
+            if (forceRefresh || NeedsRefresh(current))
+            {
+                current = await RefreshCredentialsLockedAsync(current, cancellationToken).ConfigureAwait(false);
+            }
+
+            return current.Clone();
+        }
+        finally
+        {
+            credentialLock.Release();
+        }
+    }
+
+    private async Task RefreshAfterUnauthorizedAsync(
+        string rejectedAccessToken,
+        CancellationToken cancellationToken)
+    {
+        await credentialLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            CodexOAuthCredentials current = credentials
+                ?? throw new CodexOAuthException("ChatGPT authentication is required. Start browser OAuth login first.");
+
+            if (string.Equals(current.AccessToken, rejectedAccessToken, StringComparison.Ordinal))
+            {
+                await RefreshCredentialsLockedAsync(current, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            credentialLock.Release();
+        }
+    }
+
+    private bool NeedsRefresh(CodexOAuthCredentials current)
+    {
+        if (current.ExpiresAtUtc.HasValue)
+        {
+            return current.ExpiresAtUtc.Value <= DateTimeOffset.UtcNow + options.RefreshBeforeExpiration;
+        }
+
+        return current.LastRefreshUtc + FallbackRefreshInterval <= DateTimeOffset.UtcNow;
+    }
+
+    private async Task<CodexOAuthCredentials> RefreshCredentialsLockedAsync(
+        CodexOAuthCredentials current,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(current.RefreshToken))
+        {
+            throw new CodexOAuthException("The stored ChatGPT credentials do not contain a refresh token.");
+        }
+
+        JObject payload = new JObject
+        {
+            ["client_id"] = options.ClientId,
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = current.RefreshToken
+        };
+        using HttpRequestMessage request = new HttpRequestMessage(
+            HttpMethod.Post,
+            CodexOAuthProtocol.GetIssuerEndpoint(options, "oauth/token"))
+        {
+            Content = new StringContent(payload.ToString(Formatting.None), Encoding.UTF8, "application/json")
+        };
+        ApplyClientHeaders(request);
+
+        using HttpResponseMessage response =
+            await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        string body = await ReadContentAsync(response.Content, cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body, "ChatGPT OAuth token refresh failed.");
+        CodexOAuthTokenResponse tokenResponse =
+            JsonConvert.DeserializeObject<CodexOAuthTokenResponse>(body)
+            ?? throw new CodexOAuthException("OpenAI returned an empty token refresh response.");
+        CodexOAuthCredentials updated = CodexOAuthProtocol.MergeCredentials(tokenResponse, current);
+        await credentialStore.SaveAsync(updated, cancellationToken).ConfigureAwait(false);
+        credentials = updated;
+        return updated;
+    }
+
+    private async Task<HttpResponseMessage> SendAuthenticatedAsync(
+        Func<HttpRequestMessage> requestFactory,
+        HttpCompletionOption completionOption,
+        CancellationToken cancellationToken)
+    {
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            CodexOAuthCredentials current =
+                await GetValidCredentialsAsync(false, cancellationToken).ConfigureAwait(false);
+            using HttpRequestMessage request = requestFactory();
+            ApplyClientHeaders(request);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", current.AccessToken);
+
+            if (!string.IsNullOrWhiteSpace(current.AccountId))
+            {
+                request.Headers.TryAddWithoutValidation("ChatGPT-Account-ID", current.AccountId);
+            }
+
+            if (current.IsFedRamp)
+            {
+                request.Headers.TryAddWithoutValidation("X-OpenAI-Fedramp", "true");
+            }
+
+            HttpResponseMessage response =
+                await httpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode != HttpStatusCode.Unauthorized || attempt > 0)
+            {
+                return response;
+            }
+
+            response.Dispose();
+            await RefreshAfterUnauthorizedAsync(current.AccessToken, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new CodexOAuthException("ChatGPT authentication failed after token refresh.");
+    }
+
+    private async Task TryRevokeAsync(
+        CodexOAuthCredentials current,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(current.RefreshToken))
+        {
+            return;
+        }
+
+        JObject payload = new JObject
+        {
+            ["token"] = current.RefreshToken,
+            ["token_type_hint"] = "refresh_token",
+            ["client_id"] = options.ClientId
+        };
+
+        try
+        {
+            using HttpRequestMessage request = new HttpRequestMessage(
+                HttpMethod.Post,
+                CodexOAuthProtocol.GetIssuerEndpoint(options, "oauth/revoke"))
+            {
+                Content = new StringContent(payload.ToString(Formatting.None), Encoding.UTF8, "application/json")
+            };
+            ApplyClientHeaders(request);
+            using HttpResponseMessage response =
+                await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException)
+        {
+        }
+    }
+
+    private void ApplyClientHeaders(HttpRequestMessage request)
+    {
+        request.Headers.TryAddWithoutValidation("originator", options.Originator);
+        request.Headers.TryAddWithoutValidation("version", ClientVersion);
+        request.Headers.TryAddWithoutValidation("User-Agent", $"{options.Originator}/{ClientVersion}");
+    }
+
+    private static CodexAccount ToAccount(CodexOAuthCredentials current)
+        => new CodexAccount
+        {
+            Type = "chatgpt",
+            Email = current.Email,
+            PlanType = current.PlanType
+        };
+
+    private static async Task<CodexOAuthTurnResult> ParseResponseStreamAsync(
+        HttpResponseMessage response,
+        string threadId,
+        Func<CodexOAuthTextDelta, Task>? onTextDelta,
+        CancellationToken cancellationToken)
+    {
+        Stream stream = await CodexTask.WithCancellation(
+            response.Content.ReadAsStreamAsync(),
+            cancellationToken).ConfigureAwait(false);
+        using StreamReader reader = new StreamReader(stream);
+        StringBuilder finalText = new StringBuilder();
+        StringBuilder eventData = new StringBuilder();
+        string? eventName = null;
+        JObject? completedResponse = null;
+        List<JObject> outputItems = [];
+        string responseId = string.Empty;
+        string? status = null;
+
+        while (true)
+        {
+            string? line = await CodexTask.WithCancellation(reader.ReadLineAsync(), cancellationToken).ConfigureAwait(false);
+            if (line is null)
+            {
+                break;
+            }
+
+            if (line.Length == 0)
+            {
+                if (eventData.Length > 0)
+                {
+                    await DispatchAsync(eventName, eventData.ToString()).ConfigureAwait(false);
+                }
+
+                eventName = null;
+                eventData.Clear();
+                continue;
+            }
+
+            if (line.StartsWith("event:", StringComparison.Ordinal))
+            {
+                eventName = line.Substring("event:".Length).Trim();
+            }
+            else if (line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                if (eventData.Length > 0)
+                {
+                    eventData.Append('\n');
+                }
+
+                eventData.Append(line.Substring("data:".Length).TrimStart());
+            }
+        }
+
+        if (eventData.Length > 0)
+        {
+            await DispatchAsync(eventName, eventData.ToString()).ConfigureAwait(false);
+        }
+
+        if (completedResponse is null)
+        {
+            throw new CodexOAuthException("Codex response stream ended before response.completed.");
+        }
+
+        if (finalText.Length == 0)
+        {
+            foreach (JObject content in outputItems
+                         .Where(item => string.Equals(item.Value<string>("type"), "message", StringComparison.Ordinal))
+                         .SelectMany(item => item["content"]?.OfType<JObject>() ?? []))
+            {
+                if (string.Equals(content.Value<string>("type"), "output_text", StringComparison.Ordinal))
+                {
+                    finalText.Append(content.Value<string>("text"));
+                }
+            }
+        }
+
+        return new CodexOAuthTurnResult(
+            threadId,
+            responseId,
+            finalText.ToString(),
+            status,
+            completedResponse,
+            outputItems);
+
+        async Task DispatchAsync(string? sseEvent, string data)
+        {
+            if (string.Equals(data, "[DONE]", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            JObject evt = JObject.Parse(data);
+            string type = evt.Value<string>("type") ?? sseEvent ?? string.Empty;
+
+            if (string.Equals(type, "response.output_text.delta", StringComparison.Ordinal))
+            {
+                string delta = evt.Value<string>("delta") ?? string.Empty;
+                responseId = evt.Value<string>("response_id") ?? responseId;
+                finalText.Append(delta);
+                if (onTextDelta is not null)
+                {
+                    await onTextDelta(new CodexOAuthTextDelta(
+                        threadId,
+                        responseId,
+                        evt.Value<string>("item_id") ?? string.Empty,
+                        delta)).ConfigureAwait(false);
+                }
+            }
+            else if (string.Equals(type, "response.completed", StringComparison.Ordinal))
+            {
+                completedResponse = evt["response"] as JObject ?? evt;
+                responseId = completedResponse.Value<string>("id") ?? responseId;
+                status = completedResponse.Value<string>("status") ?? "completed";
+                if (completedResponse["output"] is JArray completedOutput)
+                {
+                    foreach (JObject item in completedOutput.OfType<JObject>())
+                    {
+                        AddOutputItem(item);
+                    }
+                }
+            }
+            else if (string.Equals(type, "response.output_item.done", StringComparison.Ordinal)
+                     && evt["item"] is JObject outputItem)
+            {
+                AddOutputItem(outputItem);
+            }
+            else if (string.Equals(type, "response.failed", StringComparison.Ordinal)
+                     || string.Equals(type, "response.incomplete", StringComparison.Ordinal)
+                     || string.Equals(type, "error", StringComparison.Ordinal))
+            {
+                JObject error = evt["response"] as JObject ?? evt;
+                throw new CodexOAuthException(
+                    error["error"]?.ToString(Formatting.None)
+                    ?? $"Codex returned {type}.");
+            }
+        }
+
+        void AddOutputItem(JObject item)
+        {
+            string? itemId = item.Value<string>("id");
+            if (!string.IsNullOrWhiteSpace(itemId)
+                && outputItems.Any(existing =>
+                    string.Equals(existing.Value<string>("id"), itemId, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            outputItems.Add((JObject)item.DeepClone());
+        }
+    }
+
+    private static async Task<string> ReadContentAsync(
+        HttpContent content,
+        CancellationToken cancellationToken)
+        => await CodexTask.WithCancellation(content.ReadAsStringAsync(), cancellationToken).ConfigureAwait(false);
+
+    private static void EnsureSuccess(HttpResponseMessage response, string body, string message)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new CodexOAuthException(message, (int)response.StatusCode, body);
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (disposed)
+        {
+            throw new ObjectDisposedException(nameof(CodexOAuthSession));
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        credentialLock.Dispose();
+        if (ownsHttpClient)
+        {
+            httpClient.Dispose();
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return default;
+    }
+}

--- a/src/LlmTornado/Codex/CodexOAuthSession.cs
+++ b/src/LlmTornado/Codex/CodexOAuthSession.cs
@@ -41,12 +41,18 @@ public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
         ClientVersion = options.ClientVersion
                         ?? typeof(CodexOAuthSession).Assembly.GetName().Version?.ToString()
                         ?? "0.0.0";
+        CodexProtocolVersion = options.CodexProtocolVersion;
     }
 
     /// <summary>
     /// Client version sent to the Codex backend.
     /// </summary>
     public string ClientVersion { get; }
+
+    /// <summary>
+    /// Codex protocol version sent to the subscription model catalog.
+    /// </summary>
+    public string CodexProtocolVersion { get; }
 
     internal static async Task<CodexOAuthSession> ConnectAsync(
         CodexOAuthOptions options,
@@ -60,6 +66,11 @@ public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
         if (options.CredentialStore is null)
         {
             throw new ArgumentNullException(nameof(options.CredentialStore));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.CodexProtocolVersion))
+        {
+            throw new ArgumentException("Codex protocol version cannot be empty.", nameof(options));
         }
 
         CodexOAuthCredentials? credentials =
@@ -140,7 +151,7 @@ public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
         ThrowIfDisposed();
         Uri modelsUri = CodexOAuthProtocol.GetApiEndpoint(
             options,
-            $"models?client_version={Uri.EscapeDataString(ClientVersion)}");
+            $"models?client_version={Uri.EscapeDataString(CodexProtocolVersion)}");
 
         using HttpResponseMessage response = await SendAuthenticatedAsync(
             () => new HttpRequestMessage(HttpMethod.Get, modelsUri),
@@ -184,6 +195,7 @@ public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
                 Hidden = hidden,
                 IsDefault = source.Value<bool?>("is_default") ?? false,
                 DefaultReasoningEffort = source.Value<string>("default_reasoning_level") ?? string.Empty,
+                DefaultServiceTier = source.Value<string>("default_service_tier") ?? string.Empty,
                 SupportsPersonality = source.Value<bool?>("supports_personality") ?? false,
                 InputModalities = source["input_modalities"]?.Values<string>().ToList() ?? []
             };
@@ -196,6 +208,19 @@ public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
                     {
                         ReasoningEffort = effort.Value<string>("effort") ?? string.Empty,
                         Description = effort.Value<string>("description") ?? string.Empty
+                    });
+                }
+            }
+
+            if (source["service_tiers"] is JArray serviceTiers)
+            {
+                foreach (JObject serviceTier in serviceTiers.OfType<JObject>())
+                {
+                    model.ServiceTiers.Add(new CodexServiceTier
+                    {
+                        Id = serviceTier.Value<string>("id") ?? string.Empty,
+                        DisplayName = serviceTier.Value<string>("name") ?? string.Empty,
+                        Description = serviceTier.Value<string>("description") ?? string.Empty
                     });
                 }
             }
@@ -318,6 +343,11 @@ public sealed class CodexOAuthSession : IDisposable, IAsyncDisposable
                 ["effort"] = turnOptions.ReasoningEffort,
                 ["summary"] = "auto"
             };
+        }
+
+        if (!string.IsNullOrWhiteSpace(turnOptions.ServiceTier))
+        {
+            payload["service_tier"] = turnOptions.ServiceTier;
         }
 
         Uri responsesUri = CodexOAuthProtocol.GetApiEndpoint(options, "responses");

--- a/src/LlmTornado/Codex/CodexOAuthThread.cs
+++ b/src/LlmTornado/Codex/CodexOAuthThread.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// A text-only client-side thread using direct ChatGPT subscription OAuth.
+/// </summary>
+public sealed class CodexOAuthThread
+{
+    private readonly CodexOAuthSession session;
+    private readonly string baseInstructions;
+    private readonly List<JObject> history = [];
+    private readonly SemaphoreSlim turnLock = new SemaphoreSlim(1, 1);
+
+    internal CodexOAuthThread(
+        CodexOAuthSession session,
+        string id,
+        string model,
+        string baseInstructions,
+        string? developerInstructions)
+    {
+        this.session = session;
+        this.baseInstructions = baseInstructions;
+        Id = id;
+        Model = model;
+
+        if (!string.IsNullOrWhiteSpace(developerInstructions))
+        {
+            history.Add(CreateMessage("developer", developerInstructions!));
+        }
+    }
+
+    /// <summary>
+    /// Client-side thread identifier.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Default model selected for this thread.
+    /// </summary>
+    public string Model { get; }
+
+    /// <summary>
+    /// Runs one text-only turn and waits for the streamed response to complete.
+    /// </summary>
+    public async Task<CodexOAuthTurnResult> RunAsync(
+        string input,
+        CodexOAuthTurnOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            throw new ArgumentException("Codex input cannot be empty.", nameof(input));
+        }
+
+        await turnLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            JObject userMessage = CreateMessage("user", input);
+            List<JObject> turnInput = history
+                .Select(item => (JObject)item.DeepClone())
+                .ToList();
+            turnInput.Add(userMessage);
+
+            CodexOAuthTurnResult result = await session.RunTextTurnAsync(
+                Id,
+                Model,
+                baseInstructions,
+                turnInput,
+                options ?? new CodexOAuthTurnOptions(),
+                cancellationToken).ConfigureAwait(false);
+            history.Add(userMessage);
+            history.AddRange(result.OutputItems.Select(item => (JObject)item.DeepClone()));
+
+            bool hasAssistantMessage = result.OutputItems.Any(item =>
+                string.Equals(item.Value<string>("type"), "message", StringComparison.Ordinal)
+                && string.Equals(item.Value<string>("role"), "assistant", StringComparison.Ordinal));
+            if (!hasAssistantMessage)
+            {
+                history.Add(CreateMessage("assistant", result.FinalResponse, "output_text"));
+            }
+
+            return result;
+        }
+        finally
+        {
+            turnLock.Release();
+        }
+    }
+
+    private static JObject CreateMessage(string role, string text, string contentType = "input_text")
+        => new JObject
+        {
+            ["type"] = "message",
+            ["role"] = role,
+            ["content"] = new JArray
+            {
+                new JObject
+                {
+                    ["type"] = contentType,
+                    ["text"] = text
+                }
+            }
+        };
+}

--- a/src/LlmTornado/Codex/CodexOAuthTransport.cs
+++ b/src/LlmTornado/Codex/CodexOAuthTransport.cs
@@ -1,0 +1,397 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Codex;
+
+internal sealed class CodexOAuthLoginOperation
+{
+    private readonly CodexOAuthSession session;
+    private readonly TcpListener listener;
+    private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
+    private readonly TaskCompletionSource<CodexOAuthLoginResult> completion =
+        new TaskCompletionSource<CodexOAuthLoginResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly string state;
+    private readonly string codeVerifier;
+    private readonly Uri redirectUri;
+
+    private CodexOAuthLoginOperation(
+        CodexOAuthSession session,
+        TcpListener listener,
+        int callbackPort,
+        string state,
+        string codeVerifier,
+        Uri redirectUri,
+        Uri authorizationUrl)
+    {
+        this.session = session;
+        this.listener = listener;
+        this.state = state;
+        this.codeVerifier = codeVerifier;
+        this.redirectUri = redirectUri;
+        CallbackPort = callbackPort;
+        AuthorizationUrl = authorizationUrl;
+        _ = ListenAsync();
+    }
+
+    internal Uri AuthorizationUrl { get; }
+    internal int CallbackPort { get; }
+
+    internal static CodexOAuthLoginOperation Start(CodexOAuthSession session, CodexOAuthOptions options)
+    {
+        TcpListener listener = Bind(options.CallbackPort, options.FallbackCallbackPort);
+        int callbackPort = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Uri redirectUri = new Uri($"http://localhost:{callbackPort}/auth/callback");
+        string state = CodexOAuthProtocol.GenerateRandomBase64Url(32);
+        string codeVerifier = CodexOAuthProtocol.GenerateRandomBase64Url(64);
+        string codeChallenge = CodexOAuthProtocol.CreateCodeChallenge(codeVerifier);
+        Uri authorizationUrl = CodexOAuthProtocol.BuildAuthorizationUrl(
+            options,
+            redirectUri,
+            state,
+            codeChallenge);
+
+        return new CodexOAuthLoginOperation(
+            session,
+            listener,
+            callbackPort,
+            state,
+            codeVerifier,
+            redirectUri,
+            authorizationUrl);
+    }
+
+    internal Task<CodexOAuthLoginResult> WaitAsync(CancellationToken cancellationToken)
+        => CodexTask.WithCancellation(completion.Task, cancellationToken);
+
+    internal Task CancelAsync()
+    {
+        try
+        {
+            cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        listener.Stop();
+        completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Login cancelled."));
+        return Task.CompletedTask;
+    }
+
+    private async Task ListenAsync()
+    {
+        try
+        {
+            using (cancellation.Token.Register(state => ((TcpListener)state!).Stop(), listener))
+            using (TcpClient client = await CodexTask.WithCancellation(listener.AcceptTcpClientAsync(), cancellation.Token).ConfigureAwait(false))
+            using (NetworkStream stream = client.GetStream())
+            {
+                string? requestTarget = await ReadRequestTargetAsync(stream, cancellation.Token).ConfigureAwait(false);
+                if (requestTarget is null)
+                {
+                    await WriteResponseAsync(stream, 400, "Invalid OAuth callback.").ConfigureAwait(false);
+                    completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Invalid OAuth callback."));
+                    return;
+                }
+
+                Uri callback = new Uri("http://localhost" + requestTarget);
+                if (!string.Equals(callback.AbsolutePath, "/auth/callback", StringComparison.Ordinal))
+                {
+                    await WriteResponseAsync(stream, 404, "Invalid OAuth callback.").ConfigureAwait(false);
+                    completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Invalid OAuth callback."));
+                    return;
+                }
+
+                Dictionary<string, string> query = CodexOAuthProtocol.ParseQuery(callback.Query);
+
+                if (!query.TryGetValue("state", out string? returnedState)
+                    || !CodexOAuthProtocol.FixedTimeEquals(state, returnedState))
+                {
+                    await WriteResponseAsync(stream, 400, "OAuth state validation failed.").ConfigureAwait(false);
+                    completion.TrySetResult(new CodexOAuthLoginResult(false, null, "OAuth state validation failed."));
+                    return;
+                }
+
+                if (query.TryGetValue("error", out string? oauthError))
+                {
+                    query.TryGetValue("error_description", out string? description);
+                    string message = string.IsNullOrWhiteSpace(description) ? oauthError : description;
+                    await WriteResponseAsync(stream, 400, "ChatGPT sign-in was not completed.").ConfigureAwait(false);
+                    completion.TrySetResult(new CodexOAuthLoginResult(false, null, message));
+                    return;
+                }
+
+                if (!query.TryGetValue("code", out string? code) || string.IsNullOrWhiteSpace(code))
+                {
+                    await WriteResponseAsync(stream, 400, "Authorization code is missing.").ConfigureAwait(false);
+                    completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Authorization code is missing."));
+                    return;
+                }
+
+                CodexAccount account = await session.CompleteBrowserLoginAsync(
+                    code,
+                    redirectUri,
+                    codeVerifier,
+                    cancellation.Token).ConfigureAwait(false);
+
+                await WriteResponseAsync(stream, 200, "ChatGPT sign-in completed. You can close this window.").ConfigureAwait(false);
+                completion.TrySetResult(new CodexOAuthLoginResult(true, account, null));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Login cancelled."));
+        }
+        catch (ObjectDisposedException) when (cancellation.IsCancellationRequested)
+        {
+            completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Login cancelled."));
+        }
+        catch (SocketException) when (cancellation.IsCancellationRequested)
+        {
+            completion.TrySetResult(new CodexOAuthLoginResult(false, null, "Login cancelled."));
+        }
+        catch (Exception exception)
+        {
+            completion.TrySetResult(new CodexOAuthLoginResult(false, null, exception.Message));
+        }
+        finally
+        {
+            listener.Stop();
+            cancellation.Dispose();
+        }
+    }
+
+    private static TcpListener Bind(int preferredPort, int fallbackPort)
+    {
+        TcpListener preferred = new TcpListener(IPAddress.Loopback, preferredPort);
+        try
+        {
+            preferred.Start();
+            return preferred;
+        }
+        catch (SocketException) when (fallbackPort != preferredPort)
+        {
+            preferred.Stop();
+            TcpListener fallback = new TcpListener(IPAddress.Loopback, fallbackPort);
+            fallback.Start();
+            return fallback;
+        }
+    }
+
+    private static async Task<string?> ReadRequestTargetAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using StreamReader reader = new StreamReader(stream, Encoding.ASCII, false, 1024, true);
+        string? requestLine = await CodexTask.WithCancellation(reader.ReadLineAsync(), cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(requestLine))
+        {
+            return null;
+        }
+
+        string[] parts = requestLine.Split(' ');
+        if (parts.Length < 2 || !string.Equals(parts[0], "GET", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        while (!string.IsNullOrEmpty(await CodexTask.WithCancellation(reader.ReadLineAsync(), cancellationToken).ConfigureAwait(false)))
+        {
+        }
+
+        return parts[1];
+    }
+
+    private static async Task WriteResponseAsync(Stream stream, int statusCode, string message)
+    {
+        string statusText = statusCode switch
+        {
+            200 => "OK",
+            404 => "Not Found",
+            _ => "Bad Request"
+        };
+        string html = $"<!doctype html><html><body><p>{WebUtility.HtmlEncode(message)}</p></body></html>";
+        byte[] body = Encoding.UTF8.GetBytes(html);
+        string headers =
+            $"HTTP/1.1 {statusCode} {statusText}\r\n" +
+            "Content-Type: text/html; charset=utf-8\r\n" +
+            $"Content-Length: {body.Length}\r\n" +
+            "Connection: close\r\n\r\n";
+        byte[] headerBytes = Encoding.ASCII.GetBytes(headers);
+        await stream.WriteAsync(headerBytes, 0, headerBytes.Length).ConfigureAwait(false);
+        await stream.WriteAsync(body, 0, body.Length).ConfigureAwait(false);
+        await stream.FlushAsync().ConfigureAwait(false);
+    }
+}
+
+internal static class CodexOAuthProtocol
+{
+    private const string Scope = "openid profile email offline_access api.connectors.read api.connectors.invoke";
+
+    internal static Uri BuildAuthorizationUrl(
+        CodexOAuthOptions options,
+        Uri redirectUri,
+        string state,
+        string codeChallenge)
+    {
+        Dictionary<string, string> query = new Dictionary<string, string>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = options.ClientId,
+            ["redirect_uri"] = redirectUri.AbsoluteUri,
+            ["scope"] = Scope,
+            ["code_challenge"] = codeChallenge,
+            ["code_challenge_method"] = "S256",
+            ["id_token_add_organizations"] = "true",
+            ["codex_cli_simplified_flow"] = "true",
+            ["state"] = state,
+            ["originator"] = options.Originator
+        };
+
+        string queryString = string.Join(
+            "&",
+            query.Select(pair => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value)}"));
+        return new Uri($"{options.Issuer.AbsoluteUri.TrimEnd('/')}/oauth/authorize?{queryString}");
+    }
+
+    internal static Uri GetIssuerEndpoint(CodexOAuthOptions options, string path)
+        => new Uri($"{options.Issuer.AbsoluteUri.TrimEnd('/')}/{path.TrimStart('/')}");
+
+    internal static Uri GetApiEndpoint(CodexOAuthOptions options, string path)
+        => new Uri(options.ApiBaseUri, path.TrimStart('/'));
+
+    internal static string GenerateRandomBase64Url(int byteCount)
+    {
+        byte[] bytes = new byte[byteCount];
+        using RandomNumberGenerator random = RandomNumberGenerator.Create();
+        random.GetBytes(bytes);
+        return Base64UrlEncode(bytes);
+    }
+
+    internal static string CreateCodeChallenge(string codeVerifier)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        return Base64UrlEncode(sha256.ComputeHash(Encoding.ASCII.GetBytes(codeVerifier)));
+    }
+
+    internal static Dictionary<string, string> ParseQuery(string query)
+    {
+        Dictionary<string, string> values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string pair in query.TrimStart('?').Split('&'))
+        {
+            if (string.IsNullOrWhiteSpace(pair))
+            {
+                continue;
+            }
+
+            int separator = pair.IndexOf('=');
+            string key = separator < 0 ? pair : pair.Substring(0, separator);
+            string value = separator < 0 ? string.Empty : pair.Substring(separator + 1);
+            values[DecodeQueryValue(key)] = DecodeQueryValue(value);
+        }
+
+        return values;
+    }
+
+    internal static bool FixedTimeEquals(string expected, string actual)
+    {
+        byte[] expectedBytes = Encoding.UTF8.GetBytes(expected);
+        byte[] actualBytes = Encoding.UTF8.GetBytes(actual);
+        int difference = expectedBytes.Length ^ actualBytes.Length;
+        int count = Math.Max(expectedBytes.Length, actualBytes.Length);
+
+        for (int i = 0; i < count; i++)
+        {
+            byte left = i < expectedBytes.Length ? expectedBytes[i] : (byte)0;
+            byte right = i < actualBytes.Length ? actualBytes[i] : (byte)0;
+            difference |= left ^ right;
+        }
+
+        return difference == 0;
+    }
+
+    internal static CodexOAuthCredentials MergeCredentials(
+        CodexOAuthTokenResponse response,
+        CodexOAuthCredentials? previous)
+    {
+        string idToken = response.IdToken ?? previous?.IdToken ?? string.Empty;
+        string accessToken = response.AccessToken ?? previous?.AccessToken ?? string.Empty;
+        string refreshToken = response.RefreshToken ?? previous?.RefreshToken ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(accessToken) || string.IsNullOrWhiteSpace(refreshToken))
+        {
+            throw new CodexOAuthException("OpenAI did not return complete OAuth credentials.");
+        }
+
+        JObject idClaims = DecodeJwtClaims(idToken);
+        JObject accessClaims = DecodeJwtClaims(accessToken);
+        JObject? idAuth = idClaims["https://api.openai.com/auth"] as JObject;
+        JObject? accessAuth = accessClaims["https://api.openai.com/auth"] as JObject;
+        JObject? profile = idClaims["https://api.openai.com/profile"] as JObject;
+        long? expiration = accessClaims.Value<long?>("exp");
+
+        return new CodexOAuthCredentials
+        {
+            IdToken = idToken,
+            AccessToken = accessToken,
+            RefreshToken = refreshToken,
+            AccountId = idAuth?.Value<string>("chatgpt_account_id")
+                        ?? accessAuth?.Value<string>("chatgpt_account_id")
+                        ?? previous?.AccountId,
+            Email = idClaims.Value<string>("email")
+                    ?? profile?.Value<string>("email")
+                    ?? previous?.Email,
+            PlanType = idAuth?.Value<string>("chatgpt_plan_type")
+                       ?? accessAuth?.Value<string>("chatgpt_plan_type")
+                       ?? previous?.PlanType,
+            IsFedRamp = idAuth?.Value<bool?>("chatgpt_account_is_fedramp")
+                        ?? accessAuth?.Value<bool?>("chatgpt_account_is_fedramp")
+                        ?? previous?.IsFedRamp
+                        ?? false,
+            ExpiresAtUtc = expiration.HasValue
+                ? DateTimeOffset.FromUnixTimeSeconds(expiration.Value)
+                : response.ExpiresIn.HasValue
+                    ? DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn.Value)
+                    : previous?.ExpiresAtUtc,
+            LastRefreshUtc = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static JObject DecodeJwtClaims(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return new JObject();
+        }
+
+        string[] segments = token.Split('.');
+        if (segments.Length < 2)
+        {
+            return new JObject();
+        }
+
+        try
+        {
+            string payload = segments[1].Replace('-', '+').Replace('_', '/');
+            payload = payload.PadRight(payload.Length + ((4 - payload.Length % 4) % 4), '=');
+            return JObject.Parse(Encoding.UTF8.GetString(Convert.FromBase64String(payload)));
+        }
+        catch (Exception)
+        {
+            return new JObject();
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] value)
+        => Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static string DecodeQueryValue(string value)
+        => Uri.UnescapeDataString(value.Replace("+", " "));
+}

--- a/src/LlmTornado/Codex/CodexSession.cs
+++ b/src/LlmTornado/Codex/CodexSession.cs
@@ -1,0 +1,603 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// A live connection to the official Codex app-server.
+/// </summary>
+public sealed class CodexSession : IDisposable, IAsyncDisposable
+{
+    private readonly CodexAppServerOptions options;
+    private readonly ICodexAppServerTransport transport;
+    private readonly CancellationTokenSource shutdown = new CancellationTokenSource();
+    private readonly SemaphoreSlim writeLock = new SemaphoreSlim(1, 1);
+    private readonly ConcurrentDictionary<long, TaskCompletionSource<JToken>> pendingRequests = new ConcurrentDictionary<long, TaskCompletionSource<JToken>>();
+    private readonly ConcurrentDictionary<string, CodexNotificationQueue> turnNotifications = new ConcurrentDictionary<string, CodexNotificationQueue>(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<CodexLoginResult>> loginCompletions = new ConcurrentDictionary<string, TaskCompletionSource<CodexLoginResult>>(StringComparer.Ordinal);
+    private long nextRequestId;
+    private Task? readerTask;
+    private bool disposed;
+
+    private CodexSession(CodexAppServerOptions options, ICodexAppServerTransport transport)
+    {
+        this.options = options;
+        this.transport = transport;
+    }
+
+    /// <summary>
+    /// Initialization metadata reported by the connected app-server.
+    /// </summary>
+    public CodexInitialization Initialization { get; private set; } = new CodexInitialization();
+
+    /// <summary>
+    /// Recent app-server diagnostic lines written to stderr.
+    /// </summary>
+    public IReadOnlyCollection<string> RecentStandardError => transport.RecentStandardError;
+
+    /// <summary>
+    /// Raised for every app-server notification.
+    /// </summary>
+    public event Action<CodexNotification>? NotificationReceived;
+
+    internal static Task<CodexSession> ConnectAsync(CodexAppServerOptions options, CancellationToken cancellationToken)
+        => ConnectAsync(options, new CodexProcessTransport(options), cancellationToken);
+
+    internal static async Task<CodexSession> ConnectAsync(
+        CodexAppServerOptions options,
+        ICodexAppServerTransport transport,
+        CancellationToken cancellationToken = default)
+    {
+        CodexSession session = new CodexSession(options, transport);
+
+        try
+        {
+            await transport.StartAsync(cancellationToken).ConfigureAwait(false);
+            session.readerTask = session.ReadMessagesAsync();
+
+            JObject initializeParams = new JObject
+            {
+                ["clientInfo"] = new JObject
+                {
+                    ["name"] = options.ClientName,
+                    ["title"] = options.ClientTitle,
+                    ["version"] = options.ClientVersion ?? typeof(TornadoApi).Assembly.GetName().Version?.ToString() ?? "unknown"
+                }
+            };
+
+            JToken initialization = await session.RequestAsync("initialize", initializeParams, cancellationToken).ConfigureAwait(false);
+            session.Initialization = initialization.ToObject<CodexInitialization>() ?? new CodexInitialization();
+            await session.SendNotificationAsync("initialized", cancellationToken).ConfigureAwait(false);
+            return session;
+        }
+        catch
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Reads the currently authenticated Codex account. Token refresh remains owned by the app-server.
+    /// </summary>
+    public async Task<CodexAccountResult> GetAccountAsync(
+        bool refreshToken = false,
+        CancellationToken cancellationToken = default)
+    {
+        JObject parameters = new JObject { ["refreshToken"] = refreshToken };
+        JToken result = await RequestAsync("account/read", parameters, cancellationToken).ConfigureAwait(false);
+        return result.ToObject<CodexAccountResult>() ?? new CodexAccountResult();
+    }
+
+    /// <summary>
+    /// Starts the official ChatGPT browser login flow. The caller opens the returned URL.
+    /// </summary>
+    public async Task<CodexBrowserLogin> StartBrowserLoginAsync(CancellationToken cancellationToken = default)
+    {
+        JToken result = await RequestAsync(
+            "account/login/start",
+            new JObject { ["type"] = "chatgpt" },
+            cancellationToken).ConfigureAwait(false);
+
+        string loginId = result.Value<string>("loginId")
+                         ?? throw new InvalidOperationException("Codex app-server did not return a loginId.");
+        string authUrl = result.Value<string>("authUrl")
+                         ?? throw new InvalidOperationException("Codex app-server did not return an authUrl.");
+
+        loginCompletions.GetOrAdd(loginId, CreateLoginCompletion);
+        return new CodexBrowserLogin(this, loginId, new Uri(authUrl, UriKind.Absolute));
+    }
+
+    /// <summary>
+    /// Logs out of the Codex account. Stored credentials are removed by the app-server.
+    /// </summary>
+    public async Task LogoutAsync(CancellationToken cancellationToken = default)
+    {
+        await RequestAsync("account/logout", null, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Lists models advertised for the current Codex account, preserving server order.
+    /// </summary>
+    public async Task<IReadOnlyList<CodexModel>> ListModelsAsync(
+        bool includeHidden = false,
+        CancellationToken cancellationToken = default)
+    {
+        List<CodexModel> models = [];
+        string? cursor = null;
+
+        do
+        {
+            JObject parameters = new JObject { ["includeHidden"] = includeHidden };
+
+            if (cursor is not null)
+            {
+                parameters["cursor"] = cursor;
+            }
+
+            JToken result = await RequestAsync("model/list", parameters, cancellationToken).ConfigureAwait(false);
+            CodexModelPage page = result.ToObject<CodexModelPage>() ?? new CodexModelPage();
+            models.AddRange(page.Data);
+            cursor = page.NextCursor;
+        }
+        while (!string.IsNullOrEmpty(cursor));
+
+        return models;
+    }
+
+    /// <summary>
+    /// Starts a new Codex thread with a model selected from <see cref="ListModelsAsync"/>.
+    /// </summary>
+    public async Task<CodexThread> StartThreadAsync(
+        CodexThreadOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        CodexThreadOptions effectiveOptions = options ?? new CodexThreadOptions();
+        JObject parameters = new JObject();
+        AddIfNotNull(parameters, "model", effectiveOptions.Model);
+        AddIfNotNull(parameters, "cwd", effectiveOptions.WorkingDirectory);
+        AddIfNotNull(parameters, "approvalPolicy", effectiveOptions.ApprovalPolicy);
+        AddIfNotNull(parameters, "sandbox", effectiveOptions.Sandbox);
+
+        if (effectiveOptions.Ephemeral.HasValue)
+        {
+            parameters["ephemeral"] = effectiveOptions.Ephemeral.Value;
+        }
+
+        JToken result = await RequestAsync("thread/start", parameters, cancellationToken).ConfigureAwait(false);
+        JObject thread = result["thread"] as JObject
+                         ?? throw new InvalidOperationException("Codex app-server did not return a thread.");
+        string threadId = thread.Value<string>("id")
+                          ?? throw new InvalidOperationException("Codex app-server returned a thread without an id.");
+        return new CodexThread(this, threadId, result.Value<string>("model") ?? effectiveOptions.Model);
+    }
+
+    internal Task<CodexLoginResult> WaitForLoginAsync(string loginId, CancellationToken cancellationToken)
+    {
+        TaskCompletionSource<CodexLoginResult> completion = loginCompletions.GetOrAdd(loginId, CreateLoginCompletion);
+        return CodexTask.WithCancellation(completion.Task, cancellationToken);
+    }
+
+    internal async Task CancelLoginAsync(string loginId, CancellationToken cancellationToken)
+    {
+        await RequestAsync(
+            "account/login/cancel",
+            new JObject { ["loginId"] = loginId },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async Task<CodexTurnResult> RunTextTurnAsync(
+        string threadId,
+        string input,
+        CodexTurnOptions options,
+        CancellationToken cancellationToken)
+    {
+        JObject parameters = new JObject
+        {
+            ["threadId"] = threadId,
+            ["input"] = new JArray
+            {
+                new JObject
+                {
+                    ["type"] = "text",
+                    ["text"] = input
+                }
+            }
+        };
+        AddIfNotNull(parameters, "model", options.Model);
+        AddIfNotNull(parameters, "effort", options.ReasoningEffort);
+
+        JToken response = await RequestAsync("turn/start", parameters, cancellationToken).ConfigureAwait(false);
+        JObject initialTurn = response["turn"] as JObject
+                              ?? throw new InvalidOperationException("Codex app-server did not return a turn.");
+        string turnId = initialTurn.Value<string>("id")
+                        ?? throw new InvalidOperationException("Codex app-server returned a turn without an id.");
+        CodexNotificationQueue notifications = turnNotifications.GetOrAdd(turnId, _ => new CodexNotificationQueue());
+        StringBuilder finalResponse = new StringBuilder();
+
+        try
+        {
+            while (true)
+            {
+                CodexNotification notification = await notifications.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+                if (notification.Method == "item/agentMessage/delta")
+                {
+                    string delta = notification.Parameters.Value<string>("delta") ?? string.Empty;
+                    finalResponse.Append(delta);
+
+                    if (options.OnTextDelta is not null)
+                    {
+                        CodexTextDelta textDelta = new CodexTextDelta(
+                            notification.Parameters.Value<string>("threadId") ?? threadId,
+                            notification.Parameters.Value<string>("turnId") ?? turnId,
+                            notification.Parameters.Value<string>("itemId") ?? string.Empty,
+                            delta);
+                        await options.OnTextDelta(textDelta).ConfigureAwait(false);
+                    }
+
+                    continue;
+                }
+
+                if (notification.Method != "turn/completed")
+                {
+                    continue;
+                }
+
+                JObject completedTurn = notification.Parameters["turn"] as JObject ?? initialTurn;
+                string? status = completedTurn.Value<string>("status");
+                return new CodexTurnResult(threadId, turnId, finalResponse.ToString(), status, completedTurn);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            await TryInterruptTurnAsync(threadId, turnId).ConfigureAwait(false);
+            throw;
+        }
+        finally
+        {
+            turnNotifications.TryRemove(turnId, out _);
+        }
+    }
+
+    private async Task TryInterruptTurnAsync(string threadId, string turnId)
+    {
+        try
+        {
+            await RequestAsync(
+                "turn/interrupt",
+                new JObject
+                {
+                    ["threadId"] = threadId,
+                    ["turnId"] = turnId
+                },
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+    }
+
+    private async Task<JToken> RequestAsync(string method, JObject? parameters, CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        long id = Interlocked.Increment(ref nextRequestId);
+        TaskCompletionSource<JToken> completion = new TaskCompletionSource<JToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (!pendingRequests.TryAdd(id, completion))
+        {
+            throw new InvalidOperationException($"Duplicate Codex request id {id}.");
+        }
+
+        JObject request = new JObject
+        {
+            ["method"] = method,
+            ["id"] = id
+        };
+
+        if (parameters is not null)
+        {
+            request["params"] = parameters;
+        }
+
+        try
+        {
+            await WriteMessageAsync(request, cancellationToken).ConfigureAwait(false);
+            return await CodexTask.WithCancellation(completion.Task, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            pendingRequests.TryRemove(id, out _);
+        }
+    }
+
+    private Task SendNotificationAsync(string method, CancellationToken cancellationToken)
+        => WriteMessageAsync(new JObject { ["method"] = method }, cancellationToken);
+
+    private async Task WriteMessageAsync(JObject message, CancellationToken cancellationToken)
+    {
+        string json = message.ToString(Formatting.None);
+        await writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await transport.WriteLineAsync(json, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            writeLock.Release();
+        }
+    }
+
+    private async Task ReadMessagesAsync()
+    {
+        try
+        {
+            while (!shutdown.IsCancellationRequested)
+            {
+                string? line = await transport.ReadLineAsync(shutdown.Token).ConfigureAwait(false);
+
+                if (line is null)
+                {
+                    throw new InvalidOperationException(BuildClosedMessage());
+                }
+
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                JObject message = JObject.Parse(line);
+                JToken? id = message["id"];
+                string? method = message.Value<string>("method");
+
+                if (id is not null && method is not null)
+                {
+                    _ = HandleServerRequestAsync(id, method, message["params"] as JObject ?? new JObject());
+                    continue;
+                }
+
+                if (id is not null)
+                {
+                    CompleteRequest(id, message);
+                    continue;
+                }
+
+                if (method is not null)
+                {
+                    DispatchNotification(new CodexNotification(method, message["params"] as JObject ?? new JObject()));
+                }
+            }
+        }
+        catch (OperationCanceledException) when (shutdown.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            FailPendingOperations(exception);
+        }
+    }
+
+    private void CompleteRequest(JToken id, JObject message)
+    {
+        if (id.Type != JTokenType.Integer || !pendingRequests.TryRemove(id.Value<long>(), out TaskCompletionSource<JToken>? completion))
+        {
+            return;
+        }
+
+        if (message["error"] is JObject error)
+        {
+            completion.TrySetException(new CodexRpcException(
+                error.Value<int?>("code") ?? -32000,
+                error.Value<string>("message") ?? "Codex app-server request failed.",
+                error["data"]));
+            return;
+        }
+
+        completion.TrySetResult(message["result"] ?? new JObject());
+    }
+
+    private void DispatchNotification(CodexNotification notification)
+    {
+        if (notification.Method == "account/login/completed")
+        {
+            string? loginId = notification.Parameters.Value<string>("loginId");
+
+            if (loginId is not null)
+            {
+                CodexLoginResult result = notification.Parameters.ToObject<CodexLoginResult>() ?? new CodexLoginResult();
+                loginCompletions.GetOrAdd(loginId, CreateLoginCompletion).TrySetResult(result);
+            }
+        }
+
+        string? turnId = notification.Parameters.Value<string>("turnId")
+                         ?? notification.Parameters["turn"]?.Value<string>("id");
+
+        if (turnId is not null)
+        {
+            turnNotifications.GetOrAdd(turnId, _ => new CodexNotificationQueue()).Enqueue(notification);
+        }
+
+        try
+        {
+            NotificationReceived?.Invoke(notification);
+        }
+        catch
+        {
+        }
+    }
+
+    private async Task HandleServerRequestAsync(JToken id, string method, JObject parameters)
+    {
+        JObject response = new JObject { ["id"] = id.DeepClone() };
+
+        try
+        {
+            if (options.ServerRequestHandler is null)
+            {
+                response["error"] = new JObject
+                {
+                    ["code"] = -32601,
+                    ["message"] = $"No handler is registered for Codex server request '{method}'."
+                };
+            }
+            else
+            {
+                JToken? result = await options.ServerRequestHandler(
+                    new CodexServerRequest(id.DeepClone(), method, parameters),
+                    shutdown.Token).ConfigureAwait(false);
+                response["result"] = result ?? new JObject();
+            }
+
+            await WriteMessageAsync(response, shutdown.Token).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (!shutdown.IsCancellationRequested)
+        {
+            response.Remove("result");
+            response["error"] = new JObject
+            {
+                ["code"] = -32603,
+                ["message"] = exception.Message
+            };
+
+            try
+            {
+                await WriteMessageAsync(response, shutdown.Token).ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private void FailPendingOperations(Exception exception)
+    {
+        foreach (KeyValuePair<long, TaskCompletionSource<JToken>> request in pendingRequests.ToArray())
+        {
+            if (pendingRequests.TryRemove(request.Key, out TaskCompletionSource<JToken>? completion))
+            {
+                completion.TrySetException(exception);
+            }
+        }
+
+        foreach (CodexNotificationQueue queue in turnNotifications.Values)
+        {
+            queue.Fail(exception);
+        }
+
+        foreach (TaskCompletionSource<CodexLoginResult> completion in loginCompletions.Values)
+        {
+            completion.TrySetException(exception);
+        }
+    }
+
+    private string BuildClosedMessage()
+    {
+        string diagnostics = string.Join(Environment.NewLine, RecentStandardError.Take(20));
+        return diagnostics.Length == 0
+            ? "Codex app-server closed its output stream."
+            : $"Codex app-server closed its output stream.{Environment.NewLine}{diagnostics}";
+    }
+
+    private static TaskCompletionSource<CodexLoginResult> CreateLoginCompletion(string _)
+        => new TaskCompletionSource<CodexLoginResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static void AddIfNotNull(JObject target, string name, string? value)
+    {
+        if (value is not null)
+        {
+            target[name] = value;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (disposed)
+        {
+            throw new ObjectDisposedException(nameof(CodexSession));
+        }
+    }
+
+    /// <summary>
+    /// Stops the app-server process and releases pending operations.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        shutdown.Cancel();
+        await transport.StopAsync().ConfigureAwait(false);
+
+        if (readerTask is not null)
+        {
+            try
+            {
+                await readerTask.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+
+        FailPendingOperations(new ObjectDisposedException(nameof(CodexSession)));
+        transport.Dispose();
+        writeLock.Dispose();
+        shutdown.Dispose();
+    }
+
+    /// <summary>
+    /// Stops the app-server process and releases pending operations.
+    /// </summary>
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private sealed class CodexNotificationQueue
+    {
+        private readonly ConcurrentQueue<CodexNotification> notifications = new ConcurrentQueue<CodexNotification>();
+        private readonly SemaphoreSlim signal = new SemaphoreSlim(0);
+        private Exception? failure;
+
+        internal void Enqueue(CodexNotification notification)
+        {
+            notifications.Enqueue(notification);
+            signal.Release();
+        }
+
+        internal void Fail(Exception exception)
+        {
+            failure = exception;
+            signal.Release();
+        }
+
+        internal async Task<CodexNotification> ReadAsync(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                if (notifications.TryDequeue(out CodexNotification? notification))
+                {
+                    return notification;
+                }
+
+                if (failure is not null)
+                {
+                    throw failure;
+                }
+
+                await signal.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/LlmTornado/Codex/CodexSession.cs
+++ b/src/LlmTornado/Codex/CodexSession.cs
@@ -213,6 +213,7 @@ public sealed class CodexSession : IDisposable, IAsyncDisposable
         };
         AddIfNotNull(parameters, "model", options.Model);
         AddIfNotNull(parameters, "effort", options.ReasoningEffort);
+        AddIfNotNull(parameters, "serviceTier", options.ServiceTier);
 
         JToken response = await RequestAsync("turn/start", parameters, cancellationToken).ConfigureAwait(false);
         JObject initialTurn = response["turn"] as JObject

--- a/src/LlmTornado/Codex/CodexThread.cs
+++ b/src/LlmTornado/Codex/CodexThread.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LlmTornado.Codex;
+
+/// <summary>
+/// A text-only conversation hosted by the Codex app-server.
+/// </summary>
+public sealed class CodexThread
+{
+    private readonly CodexSession session;
+
+    internal CodexThread(CodexSession session, string id, string? model)
+    {
+        this.session = session;
+        Id = id;
+        Model = model;
+    }
+
+    /// <summary>
+    /// Codex thread identifier.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Model selected by the app-server.
+    /// </summary>
+    public string? Model { get; }
+
+    /// <summary>
+    /// Runs one text-only Codex turn and waits for completion.
+    /// </summary>
+    public Task<CodexTurnResult> RunAsync(
+        string input,
+        CodexTurnOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            throw new ArgumentException("Codex input cannot be empty.", nameof(input));
+        }
+
+        return session.RunTextTurnAsync(Id, input, options ?? new CodexTurnOptions(), cancellationToken);
+    }
+}

--- a/src/LlmTornado/Codex/CodexTransport.cs
+++ b/src/LlmTornado/Codex/CodexTransport.cs
@@ -1,0 +1,309 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LlmTornado.Codex;
+
+internal interface ICodexAppServerTransport : IDisposable
+{
+    IReadOnlyCollection<string> RecentStandardError { get; }
+    Task StartAsync(CancellationToken cancellationToken);
+    Task<string?> ReadLineAsync(CancellationToken cancellationToken);
+    Task WriteLineAsync(string line, CancellationToken cancellationToken);
+    Task StopAsync();
+}
+
+internal sealed class CodexProcessTransport : ICodexAppServerTransport
+{
+    private const int StandardErrorLimit = 400;
+    private readonly CodexAppServerOptions options;
+    private readonly ConcurrentQueue<string> standardError = new ConcurrentQueue<string>();
+    private Process? process;
+    private Task? standardErrorTask;
+
+    internal CodexProcessTransport(CodexAppServerOptions options)
+    {
+        this.options = options;
+    }
+
+    public IReadOnlyCollection<string> RecentStandardError => standardError.ToArray();
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ProcessStartInfo startInfo = new ProcessStartInfo
+        {
+            FileName = ResolveExecutablePath(options.ExecutablePath),
+            Arguments = BuildArguments(options.ConfigOverrides),
+            WorkingDirectory = options.WorkingDirectory ?? string.Empty,
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            StandardOutputEncoding = new UTF8Encoding(false),
+            StandardErrorEncoding = new UTF8Encoding(false)
+        };
+
+        foreach (KeyValuePair<string, string> variable in options.EnvironmentVariables)
+        {
+            startInfo.EnvironmentVariables[variable.Key] = variable.Value;
+        }
+
+        process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            if (!process.Start())
+            {
+                throw new InvalidOperationException($"Failed to start Codex executable '{options.ExecutablePath}'.");
+            }
+        }
+        catch (Exception exception)
+        {
+            process.Dispose();
+            process = null;
+            throw new InvalidOperationException(
+                $"Unable to start Codex app-server using '{options.ExecutablePath}'. Install Codex or set {nameof(CodexAppServerOptions.ExecutablePath)}.",
+                exception);
+        }
+
+        process.StandardInput.AutoFlush = true;
+        standardErrorTask = DrainStandardErrorAsync(process.StandardError);
+        return Task.CompletedTask;
+    }
+
+    public async Task<string?> ReadLineAsync(CancellationToken cancellationToken)
+    {
+        Process activeProcess = GetProcess();
+        return await CodexTask.WithCancellation(activeProcess.StandardOutput.ReadLineAsync(), cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task WriteLineAsync(string line, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Process activeProcess = GetProcess();
+        await activeProcess.StandardInput.WriteLineAsync(line).ConfigureAwait(false);
+        await activeProcess.StandardInput.FlushAsync().ConfigureAwait(false);
+    }
+
+    public Task StopAsync()
+    {
+        Process? activeProcess = process;
+        process = null;
+
+        if (activeProcess is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            activeProcess.StandardInput.Close();
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        try
+        {
+            if (!activeProcess.HasExited)
+            {
+                activeProcess.Kill();
+                activeProcess.WaitForExit(2_000);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        finally
+        {
+            activeProcess.Dispose();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        StopAsync().GetAwaiter().GetResult();
+    }
+
+    private Process GetProcess()
+        => process ?? throw new InvalidOperationException("The Codex app-server process is not running.");
+
+    private async Task DrainStandardErrorAsync(StreamReader reader)
+    {
+        try
+        {
+            while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line)
+            {
+                standardError.Enqueue(line);
+
+                while (standardError.Count > StandardErrorLimit)
+                {
+                    standardError.TryDequeue(out _);
+                }
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private static string BuildArguments(IEnumerable<string> configOverrides)
+    {
+        List<string> arguments = [];
+
+        foreach (string configOverride in configOverrides)
+        {
+            arguments.Add("--config");
+            arguments.Add(configOverride);
+        }
+
+        arguments.Add("app-server");
+        arguments.Add("--listen");
+        arguments.Add("stdio://");
+
+        return string.Join(" ", arguments.ConvertAll(QuoteArgument));
+    }
+
+    private static string ResolveExecutablePath(string executablePath)
+    {
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            return executablePath;
+        }
+
+        bool containsDirectory = executablePath.IndexOf(Path.DirectorySeparatorChar) >= 0
+                                 || executablePath.IndexOf(Path.AltDirectorySeparatorChar) >= 0;
+
+        if (containsDirectory && !Path.IsPathRooted(executablePath))
+        {
+            executablePath = Path.GetFullPath(executablePath);
+        }
+
+        if (Path.IsPathRooted(executablePath) && string.Equals(Path.GetExtension(executablePath), ".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return executablePath;
+        }
+
+        IEnumerable<string> searchDirectories;
+
+        if (Path.IsPathRooted(executablePath))
+        {
+            searchDirectories = [Path.GetDirectoryName(executablePath) ?? string.Empty];
+        }
+        else
+        {
+            searchDirectories = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+                .Split(Path.PathSeparator)
+                .Where(directory => !string.IsNullOrWhiteSpace(directory));
+        }
+
+        string executableName = Path.GetFileNameWithoutExtension(executablePath);
+
+        foreach (string directory in searchDirectories)
+        {
+            string directExecutable = Path.Combine(directory, executableName + ".exe");
+
+            if (File.Exists(directExecutable))
+            {
+                return directExecutable;
+            }
+
+            foreach (string nativeExecutable in GetNpmNativeExecutableCandidates(directory))
+            {
+                if (File.Exists(nativeExecutable))
+                {
+                    return nativeExecutable;
+                }
+            }
+        }
+
+        throw new FileNotFoundException(
+            $"Unable to resolve a native Codex executable from '{executablePath}'. Set {nameof(CodexAppServerOptions.ExecutablePath)} to codex.exe.",
+            executablePath);
+    }
+
+    private static IEnumerable<string> GetNpmNativeExecutableCandidates(string npmDirectory)
+    {
+        string packagesRoot = Path.Combine(npmDirectory, "node_modules", "@openai");
+        string nestedPackagesRoot = Path.Combine(packagesRoot, "codex", "node_modules", "@openai");
+
+        foreach (string packageRoot in new[] { nestedPackagesRoot, packagesRoot })
+        {
+            yield return Path.Combine(packageRoot, "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe");
+            yield return Path.Combine(packageRoot, "codex-win32-arm64", "vendor", "aarch64-pc-windows-msvc", "bin", "codex.exe");
+        }
+    }
+
+    private static string QuoteArgument(string argument)
+    {
+        if (argument.Length > 0 && argument.IndexOfAny([' ', '\t', '\n', '\v', '"']) < 0)
+        {
+            return argument;
+        }
+
+        StringBuilder quoted = new StringBuilder(argument.Length + 2);
+        quoted.Append('"');
+        int backslashCount = 0;
+
+        foreach (char character in argument)
+        {
+            if (character == '\\')
+            {
+                backslashCount++;
+                continue;
+            }
+
+            if (character == '"')
+            {
+                quoted.Append('\\', backslashCount * 2 + 1);
+                quoted.Append(character);
+                backslashCount = 0;
+                continue;
+            }
+
+            quoted.Append('\\', backslashCount);
+            quoted.Append(character);
+            backslashCount = 0;
+        }
+
+        quoted.Append('\\', backslashCount * 2);
+        quoted.Append('"');
+        return quoted.ToString();
+    }
+}
+
+internal static class CodexTask
+{
+    internal static async Task<T> WithCancellation<T>(Task<T> task, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            return await task.ConfigureAwait(false);
+        }
+
+        TaskCompletionSource<bool> cancellation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), cancellation))
+        {
+            if (task != await Task.WhenAny(task, cancellation.Task).ConfigureAwait(false))
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+        }
+
+        return await task.ConfigureAwait(false);
+    }
+}

--- a/src/LlmTornado/Codex/README.md
+++ b/src/LlmTornado/Codex/README.md
@@ -1,0 +1,230 @@
+# OpenAI Codex with a ChatGPT subscription
+
+LLMTornado supports Codex access through a ChatGPT Plus, Pro, Business, Edu, or Enterprise subscription.
+
+This is separate from the normal OpenAI API:
+
+- OpenAI API access uses an API key and supports the normal text and image endpoints.
+- Codex subscription access uses ChatGPT login, a separate model catalog, and text-only Codex threads.
+- `ChatModel.OpenAi.Codex` contains static models for the OpenAI API. Do not use it as the subscription model catalog.
+- Always call `ListModelsAsync()` to get the models available to the signed-in ChatGPT account.
+
+## Choose a connection
+
+LLMTornado provides two independent ways to connect:
+
+| Connection | Codex installation | Token owner | Use it when |
+| --- | --- | --- | --- |
+| Codex app-server | Required | Codex | The official Codex application should manage login, tokens, refresh, and agent execution. |
+| Direct browser OAuth | Not required | Your application through LLMTornado | The application should provide browser login and store the rotating refresh token itself. |
+
+Both connections use the same `TornadoApi.Codex` entry point. They use different session, thread, turn, and login types.
+
+## Codex app-server
+
+The `codex` executable must be available on `PATH`. You can also set an explicit path through `CodexAppServerOptions.ExecutablePath`.
+
+```csharp
+using System.Diagnostics;
+using LlmTornado;
+using LlmTornado.Codex;
+
+TornadoApi api = new TornadoApi();
+
+await using CodexSession codex = await api.Codex.ConnectAsync();
+
+CodexAccountResult account = await codex.GetAccountAsync();
+if (account.Account is null)
+{
+    CodexBrowserLogin login = await codex.StartBrowserLoginAsync();
+    Process.Start(new ProcessStartInfo(login.AuthorizationUrl.AbsoluteUri)
+    {
+        UseShellExecute = true
+    });
+
+    CodexLoginResult result = await login.WaitAsync();
+    if (!result.Success)
+    {
+        throw new InvalidOperationException(result.Error);
+    }
+}
+
+IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
+CodexModel model = models.First(x => x.IsDefault);
+
+CodexThread thread = await codex.StartThreadAsync(new CodexThreadOptions
+{
+    Model = model.Model
+});
+
+CodexTurnResult turn = await thread.RunAsync(
+    "Explain this project in three sentences.");
+
+Console.WriteLine(turn.FinalResponse);
+```
+
+The app-server owns token storage and refresh. LLMTornado does not read or store the ChatGPT refresh token in this mode.
+
+Call `codex.LogoutAsync()` to sign out through the app-server.
+
+## Direct browser OAuth
+
+Direct OAuth does not require a Codex installation. LLMTornado starts a localhost callback listener and returns the official `auth.openai.com` authorization URL.
+
+```csharp
+using System.Diagnostics;
+using LlmTornado;
+using LlmTornado.Codex;
+
+TornadoApi api = new TornadoApi();
+
+await using CodexOAuthSession codex = await api.Codex.ConnectOAuthAsync();
+
+CodexAccountResult account = await codex.GetAccountAsync();
+if (account.Account is null)
+{
+    CodexOAuthBrowserLogin login = await codex.StartBrowserLoginAsync();
+    Process.Start(new ProcessStartInfo(login.AuthorizationUrl.AbsoluteUri)
+    {
+        UseShellExecute = true
+    });
+
+    CodexOAuthLoginResult result = await login.WaitAsync();
+    if (!result.Success)
+    {
+        throw new InvalidOperationException(result.Error);
+    }
+}
+
+IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
+CodexModel model = models.First(x => x.IsDefault);
+
+CodexOAuthThread thread = await codex.StartThreadAsync(new CodexOAuthThreadOptions
+{
+    Model = model.Model
+});
+
+CodexOAuthTurnResult turn = await thread.RunAsync(
+    "Explain this project in three sentences.");
+
+Console.WriteLine(turn.FinalResponse);
+```
+
+The default callback port is `1455`. Port `1457` is used as a fallback. Set `CallbackPort` and `FallbackCallbackPort` in `CodexOAuthOptions` only when the OAuth redirect configuration supports those ports.
+
+Call `login.CancelAsync()` when the user cancels the browser flow. Call `codex.LogoutAsync()` to revoke the current refresh token when possible and clear the credential store.
+
+## Credential storage
+
+Direct OAuth access and refresh tokens are secrets.
+
+The default `CodexOAuthFileCredentialStore` writes credentials to:
+
+```text
+%LOCALAPPDATA%\LlmTornado\codex-oauth.json
+```
+
+Applications with their own secure storage can implement `ICodexOAuthCredentialStore`:
+
+```csharp
+await using CodexOAuthSession codex = await api.Codex.ConnectOAuthAsync(
+    new CodexOAuthOptions
+    {
+        CredentialStore = new MySecureCredentialStore()
+    });
+```
+
+The credential store must replace the complete credential set after every login and refresh. OpenAI refresh tokens can rotate, so keeping only the old refresh token will break the next refresh.
+
+Never log access tokens, ID tokens, refresh tokens, authorization codes, or complete credential objects.
+
+## Models and service tiers
+
+Subscription models are account-specific and can change over time:
+
+```csharp
+IReadOnlyList<CodexModel> models = await codex.ListModelsAsync();
+CodexModel model = models.First(x => x.IsDefault);
+```
+
+Each model can advertise reasoning efforts, service tiers, and a default service tier. Keep service-tier IDs as returned by the catalog. Unknown future IDs are valid.
+
+The `priority` tier is commonly shown as **Fast**:
+
+```csharp
+CodexServiceTier? fastTier =
+    model.ServiceTiers.FirstOrDefault(x => x.Id == "priority");
+
+CodexOAuthTurnResult turn = await thread.RunAsync(
+    "Summarize the current changes.",
+    new CodexOAuthTurnOptions
+    {
+        ReasoningEffort = "high",
+        ServiceTier = fastTier?.Id
+    });
+```
+
+Use `CodexTurnOptions` instead of `CodexOAuthTurnOptions` with an app-server thread. Omit `ServiceTier` to let the backend use the catalog default.
+
+## Streaming and multiple turns
+
+Use `OnTextDelta` to update the UI while a response is generated:
+
+```csharp
+CodexOAuthTurnResult turn = await thread.RunAsync(
+    "Explain the result.",
+    new CodexOAuthTurnOptions
+    {
+        OnTextDelta = delta =>
+        {
+            Console.Write(delta.Delta);
+            return Task.CompletedTask;
+        }
+    });
+```
+
+Reuse the same thread object for later turns:
+
+```csharp
+await thread.RunAsync("Give me a shorter version.");
+```
+
+The direct OAuth thread keeps the required response history on the client because subscription requests are not stored by the backend.
+
+## Client and protocol versions
+
+`CodexOAuthOptions.ClientVersion` identifies your application in request headers and the user agent. When it is omitted, LLMTornado uses its assembly version.
+
+`CodexOAuthOptions.CodexProtocolVersion` is a separate value used as `client_version` during model discovery. Its default is `0.146.0`.
+
+Override only the protocol version when the Codex backend requires a newer value:
+
+```csharp
+await using CodexOAuthSession codex = await api.Codex.ConnectOAuthAsync(
+    new CodexOAuthOptions
+    {
+        ClientVersion = "1.0.0",
+        CodexProtocolVersion = "0.147.0"
+    });
+```
+
+Do not use your application or LLMTornado package version as the Codex protocol version.
+
+## Lifetime and error handling
+
+- Dispose `CodexSession` and `CodexOAuthSession`. `await using` is recommended.
+- Keep a session alive while its threads are in use.
+- Do not use a thread after its session has been disposed.
+- Pass cancellation tokens to login, model, and turn operations.
+- Treat `CodexOAuthException` as an OAuth or direct backend failure.
+- Treat `CodexRpcException` as an app-server protocol failure.
+- Show login errors from `CodexLoginResult.Error` or `CodexOAuthLoginResult.Error`.
+- Retry authentication only after checking whether the stored credentials are still valid.
+
+## Limits
+
+- The public Codex thread APIs accept text input only.
+- Codex subscription access does not enable LLMTornado image generation.
+- Continue to use an OpenAI API key for normal OpenAI text, image, Realtime, and other API endpoints.
+- App-server availability depends on the installed Codex version.
+- Direct OAuth model availability depends on the signed-in ChatGPT account and current subscription.

--- a/src/LlmTornado/TornadoApi.cs
+++ b/src/LlmTornado/TornadoApi.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,6 +36,7 @@ using LlmTornado.ManagedAgents.Anthropic;
 using LlmTornado.RateLimits;
 using LlmTornado.Common;
 using LlmTornado.Compaction;
+using LlmTornado.Codex;
 
 namespace LlmTornado;
 
@@ -85,6 +86,7 @@ public class TornadoApi
     private readonly Lazy<AnthropicManagedAgentEnvironmentsEndpoint> anthropicManagedAgentEnvironments;
     private readonly Lazy<RateLimitsEndpoint> rateLimits;
     private readonly Lazy<CompactionEndpoint> compaction;
+    private readonly Lazy<CodexEndpoint> codex;
 
     /// <summary>
     ///     If true, the API will throw exceptions for non-200 responses.
@@ -142,6 +144,7 @@ public class TornadoApi
         live = new Lazy<LiveEndpoint>(() => new LiveEndpoint(this), LazyThreadSafetyMode.ExecutionAndPublication);
         rateLimits = new Lazy<RateLimitsEndpoint>(() => new RateLimitsEndpoint(this), LazyThreadSafetyMode.ExecutionAndPublication);
         compaction = new Lazy<CompactionEndpoint>(() => new CompactionEndpoint(this), LazyThreadSafetyMode.ExecutionAndPublication);
+        codex = new Lazy<CodexEndpoint>(() => new CodexEndpoint(), LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     /// <summary>
@@ -612,6 +615,11 @@ public class TornadoApi
     ///     OpenAI Realtime API (GA): client secrets, legacy sessions, and WebSocket voice/translation/transcription.
     /// </summary>
     public RealtimeEndpoint Realtime => realtime.Value;
+
+    /// <summary>
+    ///     OpenAI Codex integration for ChatGPT subscription authentication, models, and text turns.
+    /// </summary>
+    public CodexEndpoint Codex => codex.Value;
 
     /// <summary>
     ///     Anthropic Compaction API for server-side context summarization (beta).


### PR DESCRIPTION
Add ChatGPT subscription authentication for Codex through the official app-server or direct browser OAuth

This PR adds a separate Codex integration for applications that want to use a ChatGPT subscription without changing the existing OpenAI API-key flow.

What changed:
- Added `TornadoApi.Codex` as a dedicated entry point for ChatGPT subscription access
- Added an app-server session with browser login, account handling, dynamic model discovery, text threads, streamed turns, and logout
- Added a direct OAuth2 PKCE session that works without a Codex installation
- Added rotating refresh-token handling through `ICodexOAuthCredentialStore`, with file and in-memory implementations
- Added account-specific model selection, reasoning efforts, default service tiers, and optional Fast/priority turns
- Added client-managed multi-turn history for direct OAuth requests
- Separated the Codex protocol version used for model discovery from the LLMTornado client/package version
- Added a dedicated Codex guide covering both connection methods, credentials, models, service tiers, lifecycle, and limits
- Added isolated app-server and OAuth tests that do not require an API key

Why:
- ChatGPT subscription authentication is different from normal OpenAI API-key authentication and should not share the same credential path
- Some applications already use the official Codex app-server, while others need browser login without requiring a Codex installation
- Subscription model and service-tier availability is account-specific and can change, so it must come from the live catalog instead of static API model definitions
- The Codex model endpoint expects its own protocol version; using the LLMTornado package version can make model discovery fail after a successful login
- Keeping the Codex surface text-only prevents subscription credentials from being used accidentally with image-generation or other OpenAI API endpoints

Notes:
- Existing OpenAI API-key text and image behavior is unchanged
- In app-server mode, Codex owns token storage and refresh; LLMTornado does not receive the refresh token
- In direct OAuth mode, the application owns credential persistence through the configured store
- `ChatModel.OpenAi.Codex` remains the static OpenAI API model family; subscription models are returned by `ListModelsAsync()`
- Service-tier IDs are passed through as catalog values so future tiers do not require a new LLMTornado release
