### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ PRs are welcome! We are accepting new Provider implementations, contributions to
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lofcz/llmtornado&type=date&legend=top-left)](https://www.star-history.com/#lofcz/llmtornado&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lofcz/llmtornado&type=date&legend=top-left)](https://star-history.dera.page/#lofcz/llmtornado&type=date&legend=top-left)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This switches it to a working alternative that requires no API token, so the chart renders correctly again. Only the star history chart is affected; the badge is left untouched.