### PR TITLE
Fix OpenAI base64 document serialization

### DIFF
--- a/src/LlmTornado.Tests/ChatMessageDocumentSerializationTests.cs
+++ b/src/LlmTornado.Tests/ChatMessageDocumentSerializationTests.cs
@@ -1,0 +1,30 @@
+using LlmTornado.Chat;
+using LlmTornado.Code;
+using Newtonsoft.Json;
+
+namespace LlmTornado.Tests;
+
+[TestFixture]
+public class ChatMessageDocumentSerializationTests
+{
+    [Test]
+    public void OpenAiChatRequest_SerializesBase64DocumentAsFileData()
+    {
+        var request = new ChatRequest
+        {
+            Messages =
+            [
+                new ChatMessage(ChatMessageRoles.User,
+                [
+                    new ChatMessagePart("dGVzdC1kYXRh", DocumentLinkTypes.Base64),
+                    new ChatMessagePart("Summarize this document")
+                ])
+            ]
+        };
+
+        string json = JsonConvert.SerializeObject(request);
+
+        Assert.That(json, Does.Contain("\"type\":\"file\""));
+        Assert.That(json, Does.Contain("\"file_data\":\"dGVzdC1kYXRh\""));
+    }
+}

--- a/src/LlmTornado/Chat/ChatRequest.cs
+++ b/src/LlmTornado/Chat/ChatRequest.cs
@@ -1179,6 +1179,7 @@ public class ChatRequest : IModelRequest, ISerializableRequest, IHeaderProvider
 	                        ChatMessageTypes.Image => "image_url",
 	                        ChatMessageTypes.Audio => part.Audio?.Url is not null ? "audio_url" : "input_audio",
                             ChatMessageTypes.Video => "video_url",
+	                        ChatMessageTypes.Document => "file",
 	                        ChatMessageTypes.FileLink => "file",
                             _ => "text"
                         };
@@ -1273,6 +1274,32 @@ public class ChatRequest : IModelRequest, ISerializableRequest, IHeaderProvider
                                 writer.WriteEndObject();
                                 break;
                             }
+	                        case ChatMessageTypes.Document:
+	                        {
+	                        writer.WritePropertyName("file");
+	                        writer.WriteStartObject();
+
+	                        if (part.Document?.Base64 is not null)
+	                        {
+	                            writer.WritePropertyName("file_data");
+	                            writer.WriteValue(part.Document.Base64);
+	                        }
+	                        else if (part.Document?.Uri is not null)
+	                        {
+	                            writer.WritePropertyName("file_url");
+	                            writer.WriteValue(part.Document.Uri.ToString());
+
+	                            string? fileName = Path.GetFileName(part.Document.Uri.AbsolutePath);
+	                            if (!string.IsNullOrWhiteSpace(fileName))
+	                            {
+	                                writer.WritePropertyName("filename");
+	                                writer.WriteValue(fileName);
+	                            }
+	                        }
+
+	                        writer.WriteEndObject();
+	                        break;
+	                        }
 	                        case ChatMessageTypes.FileLink:
 	                        {
 		                        writer.WritePropertyName("file");


### PR DESCRIPTION
## Summary
Fixes #158 by ensuring ChatMessagePart document payloads serialize as an OpenAI ile object instead of being dropped during request creation.

## What changed
- Map ChatMessageTypes.Document to the OpenAI ile message content type.
- When the document is base64-backed, serialize it as ile_data.
- When the document is URL-backed, serialize it as ile_url and include the filename when available.
- Added a regression test covering the base64 document case.

## Root cause
The chat request serializer recognized FileLink but not Document, so base64-backed ChatDocument values were omitted from the outgoing JSON payload.
