### PR TITLE
Document optional Parallel Search MCP setup

### DIFF
--- a/src/LlmTornado.Mcp/README.md
+++ b/src/LlmTornado.Mcp/README.md
@@ -34,6 +34,19 @@ Conversation result = await agent.RunAsync("Did mom respond?");
 Console.WriteLine(result.Messages.Last().Content);
 ```
 
+### Optional Parallel Search MCP
+
+To give an agent web search and URL-fetching tools, you can explicitly opt in to the free Parallel Search MCP endpoint. It does not require a Parallel account or API key. When you use these tools, user-provided search objectives, search queries, and requested URLs are sent to Parallel. See the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp) for details.
+
+```csharp
+MCPServer searchServer = new MCPServer(
+    serverLabel: "parallel-search",
+    serverUrl: "https://search.parallel.ai/mcp");
+
+await searchServer.InitializeAsync();
+agent.AddMcpTools(searchServer.AllowedTornadoTools.ToArray());
+```
+
 ## Best Practices
 
 ### Connection Management


### PR DESCRIPTION
## Why

Adds an optional web search and URL-fetching MCP server example for LLM Tornado agents. The default endpoint does not require a Parallel account or API key, and the example is only activated when a developer explicitly adds it.

## Changes

- Show how to initialize Parallel Search MCP through the existing `MCPServer` HTTP extension point and register its tools with an agent.
- Preserve the existing Gmail example, configured providers, gateway authorization, credentials, and defaults.
- Link to the optional Parallel Search MCP documentation.
- Disclose that, when these tools are explicitly used, user-provided search objectives, search queries, and requested URLs are sent to Parallel.

## Validation

- `python3` targeted README content assertions: passed.
- `git diff --check`: passed.
- `test "$(git status --short)" = " M src/LlmTornado.Mcp/README.md"`: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.