### PR TITLE
feat: add llmman as a self-hosted provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ LLM Tornado is a .NET provider-agnostic SDK that empowers developers to build, o
 
 ## ✨ Features
 -  **Use Any Provider**: Built-in connectors to: [Alibaba](https://modelstudio.console.alibabacloud.com), [Anthropic](https://docs.anthropic.com/en/docs/intro), [Azure](https://azure.microsoft.com/en-us/products/ai-services/openai-service), [Blablador](https://sdlaml.pages.jsc.fz-juelich.de/ai/guides/blablador_api_access), [Cohere](https://docs.cohere.com/changelog), [DeepInfra](https://deepinfra.com/docs/), [DeepSeek](https://api-docs.deepseek.com/), [Google](https://ai.google.dev/gemini-api/docs), [Groq](https://console.groq.com/docs/overview), [LiteLLM](https://docs.litellm.ai/docs/simple_proxy), [MiniMax](https://platform.minimax.io/docs/guides/models-intro), [Mistral](https://docs.mistral.ai/getting-started), [MoonshotAI](https://platform.moonshot.ai/docs/overview), [OpenAI](https://platform.openai.com/docs), [OpenRouter](https://openrouter.ai/docs/quickstart), [Perplexity](https://docs.perplexity.ai/home), [Requesty](https://www.requesty.ai), [Upstage](https://www.upstage.ai), [Voyage](https://www.voyageai.com/), [xAI](https://docs.x.ai/docs), [Z.ai](https://docs.z.ai/guides/overview/quick-start), and more. Connectors expose all niche/unique features via strongly typed code and are up-to-date with the latest AI development. No dependencies on first-party SDKs. [Feature Matrix](https://github.com/lofcz/LlmTornado/blob/master/FeatureMatrix.md) tracks detailed endpoint support.
-- **First-class Local Deployments**: Run with [vLLM](https://docs.vllm.ai/en/latest), [Ollama](https://ollama.com/), or [LocalAI](https://localai.io/) with integrated support for request transformations.
+- **First-class Local Deployments**: Run with [vLLM](https://docs.vllm.ai/en/latest), [Ollama](https://ollama.com/), [llmman](https://github.com/llmmanorg/llmman), or [LocalAI](https://localai.io/) with integrated support for request transformations.
 - **Agents Orchestration**: [Coordinate specialist agents](https://llmtornado.ai/agents/getting-started) that can autonomously perform complex tasks with three core concepts: `Orchestrator` (graph), `Runner` (node), and `Advancer` (edge). Comes with [handoffs](https://llmtornado.ai/agents/agent-orchestration/basics), [parallel execution](https://llmtornado.ai/agents/chat-runtime), [Mermaid](https://mermaid.js.org) export, and [builder pattern](https://llmtornado.ai/agents/agent-orchestration/orchestration#using-the-builder) to keep it simple.
 - **Rapid Development**: Write pipelines once, execute with any Provider by changing the model's name. Connect your editor to [Context7](https://context7.com/lofcz/llmtornado) or [FSKB](https://github.com/lofcz/LlmTornado/tree/master/src/LlmTornado.FsKb/LlmTornado.FsKb) to accelerate coding with instant access to vectorized documentation.
 - **Fully Multimodal**: Text, images, videos, documents, URLs, and audio inputs/outputs are supported.
@@ -187,6 +187,12 @@ public static async Task OllamaStreaming()
         .AppendUserInput("Why is the sky blue?")
         .StreamResponse(Console.Write);
 }
+```
+
+[llmman](https://github.com/llmmanorg/llmman) serves the same Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434, so only the URI changes:
+
+```cs
+TornadoApi api = new TornadoApi(new Uri("http://localhost:17434")); // default llmman port
 ```
 
 If you need more control over requests, for example, custom headers, you can create an instance of a built-in Provider. This is useful for custom deployments like Amazon Bedrock, Vertex AI, etc.

--- a/src/LlmTornado.Demo/CustomProviderDemo.cs
+++ b/src/LlmTornado.Demo/CustomProviderDemo.cs
@@ -30,4 +30,18 @@ public class CustomProviderDemo : DemoBase
             .AppendUserInput("Why is the sky blue?")
             .StreamResponse(Console.Write);
     }
+    
+    /// <summary>
+    /// llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on port 17434, so only the URI differs.
+    /// </summary>
+    [Flaky("requires llmman")]
+    [TornadoTest]
+    public static async Task LlmmanStreaming()
+    {
+        TornadoApi api = new TornadoApi(new Uri("http://localhost:17434"));
+        
+        await api.Chat.CreateConversation(new ChatModel("gemma4"))
+            .AppendUserInput("Why is the sky blue?")
+            .StreamResponse(Console.Write);
+    }
 }

--- a/src/LlmTornado.Docs/website/docs/.vitepress/theme/ProviderSelector.vue
+++ b/src/LlmTornado.Docs/website/docs/.vitepress/theme/ProviderSelector.vue
@@ -304,6 +304,36 @@ await foreach (var chunk in conversation.StreamResponse())
         ]
       },
       {
+        id: 'llmman',
+        name: 'llmman',
+        type: 'local',
+        category: 'local',
+        icon: '📦',
+        description: 'Local model runner serving the Ollama API (plus OpenAI- and Anthropic-compatible ones) on port 17434',
+        features: ['Privacy', 'Offline', 'OCI Artifacts', 'Hugging Face'],
+        code: `// Connect to llmman (default port 17434)
+var api = new TornadoApi(new Uri("http://localhost:17434"));
+
+// Create conversation with a local model
+var conversation = api.Chat.CreateConversation(new ChatModel("gemma4"));
+
+// Stream response to console
+await foreach (var chunk in conversation.StreamResponse())
+{
+    Console.Write(chunk.Content);
+}`,
+        additionalInfo: [
+          {
+            title: 'Installation',
+            content: 'Install llmman from github.com/llmmanorg/llmman, then: llmman serve && llmman pull gemma4'
+          },
+          {
+            title: 'Available Models',
+            content: 'Pulls models as OCI artifacts (Docker Hub, GHCR, quay, ...) or from Hugging Face (hf.co/org/model); served by llama.cpp, vLLM, or mlx-lm'
+          }
+        ]
+      },
+      {
         id: 'vllm',
         name: 'vLLM',
         type: 'local',

--- a/src/LlmTornado.Docs/website/docs/1. LlmTornado/Chat/5. models.md
+++ b/src/LlmTornado.Docs/website/docs/1. LlmTornado/Chat/5. models.md
@@ -130,6 +130,24 @@ await foreach (var chunk in conversation.StreamResponse())
 
 </div>
 
+<div id="snippet-llmman" style="display:none;">
+
+```csharp
+// Connect to llmman (default port 17434)
+var api = new TornadoApi(new Uri("http://localhost:17434"));
+
+// Create conversation with a local model
+var conversation = api.Chat.CreateConversation(new ChatModel("gemma4"));
+
+// Stream response to console
+await foreach (var chunk in conversation.StreamResponse())
+{
+    Console.Write(chunk.Content);
+}
+```
+
+</div>
+
 <div id="snippet-vllm" style="display:none;">
 
 ```csharp

--- a/src/LlmTornado/TornadoApi.cs
+++ b/src/LlmTornado/TornadoApi.cs
@@ -150,6 +150,7 @@ public class TornadoApi
     /// <summary>
     ///     Creates a new Tornado API for self-hosted / custom providers, such as Ollama and vLLM.<br/>
     ///     For Ollama use "http://localhost:11434" (by default).
+    ///     For llmman use "http://localhost:17434" (by default).
     ///     For vLLM use "http://localhost:8000" (by default).
     /// </summary>
     /// <param name="serverUri">Uri of the server. Tokens {0} and {1} are available for endpoint and action respectively. If provided values doesn't use neither, format /{0}/{1} is used automatically.</param>
@@ -168,6 +169,7 @@ public class TornadoApi
     /// <summary>
     ///     Creates a new Tornado API for self-hosted / custom providers, such as Ollama and vLLM.<br/>
     ///     For Ollama use "http://localhost:11434" (by default).
+    ///     For llmman use "http://localhost:17434" (by default).
     ///     For vLLM use "http://localhost:8000" (by default).
     /// </summary>
     /// <param name="serverUri">Uri of the server. Tokens {0} and {1} are available for endpoint and action respectively. If provided values doesn't use neither, format /{0}/{1} is used automatically.</param>


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434.

LlmTornado already reaches Ollama through the generic self-hosted path (`new TornadoApi(new Uri("http://localhost:11434"))`) rather than a dedicated `LLmProviders` value, so llmman works with zero library changes; only the port differs. This PR mirrors the Ollama touchpoints so users can discover it:

- **README.md**: llmman added to the "First-class Local Deployments" bullet (next to Ollama), plus a one-line URI example under "Self-Hosted/Custom Providers" after the Ollama streaming sample.
- **src/LlmTornado/TornadoApi.cs**: one XML-doc line on both `TornadoApi(Uri ...)` constructors giving the default llmman URL, alongside the existing Ollama/vLLM lines. Comment-only, no behaviour change.
- **Docs site** (`ProviderSelector.vue` + `5. models.md`): a `llmman` entry in the Self-Hosted group directly after Ollama, with the matching pre-rendered `snippet-llmman` block the selector looks up by id. Uses a neutral 📦 icon rather than reusing Ollama's 🦙.
- **src/LlmTornado.Demo/CustomProviderDemo.cs**: `LlmmanStreaming` demo tagged `[Flaky("requires llmman")]`, identical in shape to `OllamaStreaming`.
- Deliberately **no new `LLmProviders` enum member**: Ollama does not have one either, and the `Custom` path (OpenAI-compatible `/v1/*`) is what llmman serves. Happy to add one if you'd prefer it to be addressable like `LiteLlm`.
- Embeddings: llmman does not serve Ollama's `/api/embed*`, but LlmTornado's Custom path already uses OpenAI `/v1/embeddings`, which llmman does serve, so nothing special is needed.

**Testing:** `dotnet build src/LlmTornado.Demo/LlmTornado.Demo.csproj -f net8.0` (SDK 10.0.400, which also compiles `LlmTornado`): 0 errors; no warnings originate from the two edited `.cs` files (the ~2.1k warnings are pre-existing). `node --check` on the extracted `<script>` block of `ProviderSelector.vue` passes.

Not verified: no run against a live llmman server; the VitePress site was not built.

> AI-assisted, reviewed before submitting.
